### PR TITLE
Don't need to run `build` on master as that is done via release-dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,11 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build
+      - build:
+          filters:
+            branches:
+              ignore:
+                - master
       - test-gcp:
           requires:
             - release-dev


### PR DESCRIPTION
quick fix