### PR TITLE
Update StorageService to use takeSnapshot instead of deprecated takeCFSnapshot

### DIFF
--- a/backup/pom.xml
+++ b/backup/pom.xml
@@ -103,5 +103,41 @@
 
     </dependencies>
 
-
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <mainClass>com.instaclustr.backup.BackupApplication</mainClass>
+                        </transformer>
+                    </transformers>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>${project.artifactId}-${project.version}-final</finalName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/backup/src/main/java/com/instaclustr/backup/task/BackupTask.java
+++ b/backup/src/main/java/com/instaclustr/backup/task/BackupTask.java
@@ -113,10 +113,12 @@ public class BackupTask implements Callable<Void> {
     @VisibleForTesting
     public void takeCassandraSnapshot(final StorageServiceMBean storageServiceMBean, final List<String> keyspaces, final String tag, final String columnFamily, final boolean drain) throws IOException, ExecutionException, InterruptedException {
         if (columnFamily != null) {
-            final String keyspace = Iterables.getOnlyElement(keyspaces);
+            final String tableWithKS = columnFamily + "." + Iterables.getOnlyElement(keyspaces);
 
-            logger.info("Taking snapshot \"{}\" on {}.{}.", tag, keyspace, columnFamily);
-            storageServiceMBean.takeColumnFamilySnapshot(keyspace, columnFamily, tag);
+            logger.info("Taking snapshot \"{}\" on {}.", tag, tableWithKS);
+            // Currently only supported option by Cassandra during snapshot is to skipFlush
+            // An empty map is used as skipping flush is currently not implemented.
+            storageServiceMBean.takeSnapshot(tag, Collections.emptyMap(), tableWithKS);
 
         } else {
             logger.info("Taking snapshot \"{}\" on {}.", tag, (keyspaces.isEmpty() ? "\"all\"" : keyspaces));

--- a/backup/src/main/java/jmx/org/apache/cassandra/two/zero/service/StorageServiceMBean.java
+++ b/backup/src/main/java/jmx/org/apache/cassandra/two/zero/service/StorageServiceMBean.java
@@ -200,13 +200,13 @@ public interface StorageServiceMBean extends NotificationEmitter
     public void takeSnapshot(String tag, String... keyspaceNames) throws IOException;
 
     /**
-     * Takes the snapshot of a specific column family. A snapshot name must be specified.
+     * Takes the snapshot of a multiple column family from different keyspaces. A snapshot name must be specified.
      *
-     * @param keyspaceName the keyspace which holds the specified column family
-     * @param columnFamilyName the column family to snapshot
      * @param tag the tag given to the snapshot; may not be null or empty
+     * @param options Map of options (skipFlush is the only supported option for now)
+     * @param entities list of keyspaces / tables in the form of empty | ks1 ks2 ... | ks1.cf1,ks2.cf2,...
      */
-    public void takeColumnFamilySnapshot(String keyspaceName, String columnFamilyName, String tag) throws IOException;
+    public void takeSnapshot(String tag, Map<String, String> options, String... entities) throws IOException;
 
     /**
      * Remove the snapshot with the given name from the given keyspaces.


### PR DESCRIPTION
This change will cause problems with Cassandra 2.x so some discussion around how to implement can be good. Currently trying to specify ks and cf for a snapshot causes a problem for Cassandra 3.x (tested with 3.10.1 and 3.11.2)  with the bellow exception:

Command:

```
java -jar backup-1.0-SNAPSHOT-final.jar --id cassandra_1 --cluster 127.0.0.1 --blob
-storage FILE --filebackup-location /var/lib/cassandra/backups --jmx service:jmx:rmi://127.0.0.1/jndi/rmi://127.0.0.1:7199/jmxr
mi --data-directory /var/lib/data --config-directory /cassandra/apache-cassandra-3.11.2 --cf testCF testKS
```

Logs:

```
[main] INFO com.instaclustr.backup.task.BackupTask - Taking snapshot "autosnap-1527016846" on testKS.testCF.
[main] INFO com.instaclustr.backup.task.BackupTask - Cleared snapshot "autosnap-1527016846".
Exception in thread "main" java.lang.reflect.UndeclaredThrowableException
        at com.sun.proxy.$Proxy4.takeColumnFamilySnapshot(Unknown Source)
        at com.instaclustr.backup.task.BackupTask.takeCassandraSnapshot(BackupTask.java:119)
        at com.instaclustr.backup.task.BackupTask.tryBackup(BackupTask.java:212)
        at com.instaclustr.backup.task.BackupTask.call(BackupTask.java:108)
        at com.instaclustr.backup.BackupApplication.main(BackupApplication.java:23)
Caused by: javax.management.ReflectionException: No such operation: takeColumnFamilySnapshot
        at com.sun.jmx.mbeanserver.PerInterface.noSuchMethod(PerInterface.java:170)
        at com.sun.jmx.mbeanserver.PerInterface.invoke(PerInterface.java:112)
        at com.sun.jmx.mbeanserver.MBeanSupport.invoke(MBeanSupport.java:252)
        at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.invoke(DefaultMBeanServerInterceptor.java:819)
        at com.sun.jmx.mbeanserver.JmxMBeanServer.invoke(JmxMBeanServer.java:801)
        at javax.management.remote.rmi.RMIConnectionImpl.doOperation(RMIConnectionImpl.java:1468)
        at javax.management.remote.rmi.RMIConnectionImpl.access$300(RMIConnectionImpl.java:76)
        at javax.management.remote.rmi.RMIConnectionImpl$PrivilegedOperation.run(RMIConnectionImpl.java:1309)
        at javax.management.remote.rmi.RMIConnectionImpl.doPrivilegedOperation(RMIConnectionImpl.java:1401)
        at javax.management.remote.rmi.RMIConnectionImpl.invoke(RMIConnectionImpl.java:829)
        at sun.reflect.GeneratedMethodAccessor6.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:357)
        at sun.rmi.transport.Transport$1.run(Transport.java:200)
        at sun.rmi.transport.Transport$1.run(Transport.java:197)
        at java.security.AccessController.doPrivileged(Native Method)
        at sun.rmi.transport.Transport.serviceCall(Transport.java:196)
        at sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:568)
        at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:826)
        at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:683)
        at java.security.AccessController.doPrivileged(Native Method)
        at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:682)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
        at sun.rmi.transport.StreamRemoteCall.exceptionReceivedFromServer(Unknown Source)
        at sun.rmi.transport.StreamRemoteCall.executeCall(Unknown Source)
        at sun.rmi.server.UnicastRef.invoke(Unknown Source)
        at com.sun.jmx.remote.internal.PRef.invoke(Unknown Source)
        at javax.management.remote.rmi.RMIConnectionImpl_Stub.invoke(Unknown Source)
        at javax.management.remote.rmi.RMIConnector$RemoteMBeanServerConnection.invoke(Unknown Source)
        at javax.management.MBeanServerInvocationHandler.invoke(Unknown Source)
        ... 5 more
Caused by: java.lang.NoSuchMethodException: takeColumnFamilySnapshot(java.lang.String, java.lang.String, java.lang.String)
        at com.sun.jmx.mbeanserver.PerInterface.noSuchMethod(PerInterface.java:169)
        at com.sun.jmx.mbeanserver.PerInterface.invoke(PerInterface.java:112)
        at com.sun.jmx.mbeanserver.MBeanSupport.invoke(MBeanSupport.java:252)
        at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.invoke(DefaultMBeanServerInterceptor.java:819)
        at com.sun.jmx.mbeanserver.JmxMBeanServer.invoke(JmxMBeanServer.java:801)
        at javax.management.remote.rmi.RMIConnectionImpl.doOperation(RMIConnectionImpl.java:1468)
        at javax.management.remote.rmi.RMIConnectionImpl.access$300(RMIConnectionImpl.java:76)
        at javax.management.remote.rmi.RMIConnectionImpl$PrivilegedOperation.run(RMIConnectionImpl.java:1309)
        at javax.management.remote.rmi.RMIConnectionImpl.doPrivilegedOperation(RMIConnectionImpl.java:1401)
        at javax.management.remote.rmi.RMIConnectionImpl.invoke(RMIConnectionImpl.java:829)
        at sun.reflect.GeneratedMethodAccessor6.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:357)
        at sun.rmi.transport.Transport$1.run(Transport.java:200)
        at sun.rmi.transport.Transport$1.run(Transport.java:197)
        at java.security.AccessController.doPrivileged(Native Method)
        at sun.rmi.transport.Transport.serviceCall(Transport.java:196)
        at sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:568)
        at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:826)
        at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:683)
        at java.security.AccessController.doPrivileged(Native Method)
        at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:682)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748) 
```

This is because cassandra-operator is trying to call a remote function that doesn't exist in C* 3.x, namely `takeColumnFamilySnapshot`. This function was renamed to `takeTableSnapshot` in cassandra 3.0 which in turn was deprecated. 

The update proposed here uses the latest `takeSnapshot(String tag, Map<String, String> options, String... entities)` [Link](https://github.com/apache/cassandra/blob/trunk/src/java/org/apache/cassandra/service/StorageServiceMBean.java#L249).

