### PR TITLE
Remove PVC & PV when scaling down or DC get deleted

### DIFF
--- a/java/operator/src/main/java/com/instaclustr/cassandra/operator/k8s/K8sResourceUtils.java
+++ b/java/operator/src/main/java/com/instaclustr/cassandra/operator/k8s/K8sResourceUtils.java
@@ -59,7 +59,9 @@ public class K8sResourceUtils {
     public void createOrReplaceNamespaceService(final V1Service service) throws ApiException {
         createOrReplaceResource(
                 coreApi.createNamespacedServiceCall(service.getMetadata().getNamespace(), service, null, null, null),
-                coreApi.replaceNamespacedServiceCall(service.getMetadata().getName(), service.getMetadata().getNamespace(), service, null, null, null)
+                //coreApi.replaceNamespacedServiceCall(service.getMetadata().getName(), service.getMetadata().getNamespace(), service, null, null, null)
+                // temporarily disable service replace call to fix issue #41 since service can't be customized right now
+                coreApi.readNamespacedServiceCall(service.getMetadata().getName(), service.getMetadata().getNamespace(), null, null, null, null, null)
         );
     }
 


### PR DESCRIPTION
Now when a pod get deleted (scaling down or DC delete event), it's Persistent Volume and Persistent Volume Claim will also got deleted. 