### PR TITLE
Fixes for issue #44 #55

### DIFF
--- a/java/operator/src/main/java/com/instaclustr/cassandra/operator/service/CassandraHealthCheckService.java
+++ b/java/operator/src/main/java/com/instaclustr/cassandra/operator/service/CassandraHealthCheckService.java
@@ -60,6 +60,9 @@ public class CassandraHealthCheckService extends AbstractScheduledService {
             final V1PodList podList = coreApi.listNamespacedPod(cacheEntry.getValue().getMetadata().getNamespace(), null, null, null, null, labelSelector, null, null, null, null);
 
             for (final V1Pod pod : podList.getItems()) {
+                // Skip when a Pod is not in a "Running" state
+                if (!pod.getStatus().getPhase().equals("Running")) continue;
+                
                 final InetAddress podIp = InetAddresses.forString(pod.getStatus().getPodIP());
 
                 try {

--- a/java/operator/src/main/java/com/instaclustr/cassandra/operator/service/ControllerService.java
+++ b/java/operator/src/main/java/com/instaclustr/cassandra/operator/service/ControllerService.java
@@ -125,7 +125,7 @@ public class ControllerService extends AbstractExecutionThreadService {
                     logger.info("Deleting Data Center.", dataCenterKey);
                     deleteDataCenter(dataCenterKey);
 
-                    return;
+                    continue;
                 }
 
                 // data center created or modified

--- a/java/operator/src/main/java/com/instaclustr/cassandra/operator/service/ControllerService.java
+++ b/java/operator/src/main/java/com/instaclustr/cassandra/operator/service/ControllerService.java
@@ -33,6 +33,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class ControllerService extends AbstractExecutionThreadService {
     private static final Logger logger = LoggerFactory.getLogger(ControllerService.class);
@@ -351,10 +352,12 @@ public class ControllerService extends AbstractExecutionThreadService {
 
 
         // TODO: this will be slow for a large number of nodes -- introduce some parallelism
-        final ImmutableListMultimap<CassandraConnection.Status.OperationMode, V1Pod> podCassandraOperationModes = Multimaps.index(pods, p -> {
-            final CassandraConnection cassandraConnection = cassandraConnectionFactory.connectionForPod(p);
+        final ImmutableListMultimap<CassandraConnection.Status.OperationMode, V1Pod> podCassandraOperationModes = Multimaps.index(
+                pods.stream().filter(p -> p.getStatus().getPhase().equals("Running")).collect(Collectors.toList()), 
+                p -> {
+                    final CassandraConnection cassandraConnection = cassandraConnectionFactory.connectionForPod(p);
 
-            return cassandraConnection.status().operationMode;
+                    return cassandraConnection.status().operationMode;
         });
 
 


### PR DESCRIPTION
A patch for current critical issues:

- Issue #44: Now skip `Pod`  `cassandraConnection.status()` check on `Pod` which is not in `Running` state. Also as we discussed, the ideal way is to use service to discuss `Running Pod`. However, seems there is no such APIs available for us to use.
- Issue #55: There is a typo that uses `return` instead of `continue`. Therefore, `Controller Service` thread is terminated once a `delete` event happens. 