### PR TITLE
Add logback + slf4j dependencies to java/backup module

### DIFF
--- a/java/backup/pom.xml
+++ b/java/backup/pom.xml
@@ -100,6 +100,16 @@
             <artifactId>javassist</artifactId>
             <version>3.19.0-GA</version>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <version>1.7.16</version>
+        </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
Currently the backup module removes sfl4j and logback as it's being shaded. Re-introducing these dependencies back to the backup's pom.xml allows backup to successfully use the logging implementation with a log4j.properties file (using `-Dlog4j.configuration=file:///<path_to>/log4j.properties`). For future reference we may want to include a default log4j file, but for now this solution is sufficient. 