### PR TITLE
Patch for allowing JMX Auth specification

### DIFF
--- a/java/backup/src/main/java/com/instaclustr/backup/CommonBackupArguments.java
+++ b/java/backup/src/main/java/com/instaclustr/backup/CommonBackupArguments.java
@@ -101,6 +101,14 @@ public abstract class CommonBackupArguments extends BaseArguments {
     @Option(name = "-j", aliases = {"--jmx"}, usage = "JMX service url for Cassandra", metaVar = "jmx-url", handler = JMXUrlOptionHandler.class, forbids = "--offline")
     public JMXServiceURL jmxServiceURL;
 
+    @Option(name = "--ju", usage = "JMX service user for Cassandra", metaVar = "jmx-user", forbids = "--offline")
+    @Nullable
+    public String jmxUser;
+
+    @Option(name = "--jp", usage = "JMX service password for Cassandra", metaVar = "jmx-password", forbids = "--offline")
+    @Nullable
+    public String jmxPassword;
+
     @Option(name = "--bucket", aliases = {"--backup-bucket"}, usage = "Container or bucket to store backups in", metaVar = "bucket_name")
     public String backupBucket;
 

--- a/java/backup/src/main/java/com/instaclustr/backup/task/BackupTask.java
+++ b/java/backup/src/main/java/com/instaclustr/backup/task/BackupTask.java
@@ -181,7 +181,13 @@ public class BackupTask implements Callable<Void> {
         if (arguments.offlineSnapshot) {
             doUpload(tokens);
         } else {
-            try (final JMXConnector jmxConnector = JMXConnectorFactory.connect(cassandraJMXServiceURL)) {
+            HashMap<String, String[]> environment = null; //we can pass nulls to the jmxconnectorFactory
+            if(arguments.jmxPassword != null && arguments.jmxUser != null) {
+                environment = new HashMap<>();
+                String[] credentials = new String[] {arguments.jmxUser, arguments.jmxPassword};
+                environment.put(JMXConnector.CREDENTIALS, credentials);
+            }
+            try (final JMXConnector jmxConnector = JMXConnectorFactory.connect(cassandraJMXServiceURL, environment)) {
 
                 final MBeanServerConnection cassandraMBeanServerConnection = jmxConnector.getMBeanServerConnection();
                 final StorageServiceMBean storageServiceMBean = JMX.newMBeanProxy(cassandraMBeanServerConnection, CassandraObjectNames.STORAGE_SERVICE, StorageServiceMBean.class);


### PR DESCRIPTION
This is Ben's work from his JMX Branch, hopefully I'm helping get the code commited. Original: https://github.com/benbromhead/cassandra-operator/commits/jmxAuthBackups 