### PR TITLE
Adding imagePullPolicy: Always as the default

### DIFF
--- a/examples/common/rbac-bundle.yaml
+++ b/examples/common/rbac-bundle.yaml
@@ -90,6 +90,7 @@ spec:
     spec:
       containers:
       - image: gcr.io/cassandra-operator/cassandra-operator:latest
+        imagePullPolicy: Always
         name: cassandra-operator
         ports:
         - containerPort: 8080

--- a/examples/common/test.yaml
+++ b/examples/common/test.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   replicas: 3
   image: "gcr.io/cassandra-operator/cassandra:latest"
-  imagePullPolicy: IfNotPresent
+  imagePullPolicy: Always

--- a/helm/cassandra-operator/values.yaml
+++ b/helm/cassandra-operator/values.yaml
@@ -9,7 +9,7 @@ apiVersion: stable.instaclustr.com/v1
 image:
   repository: gcr.io/cassandra-operator/cassandra-operator-dev
   tag: latest
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 resources: {}
   # Suggested resource limits for the operator itself (not cassandra), works with a reasonable sized minikube.

--- a/helm/cassandra/templates/cassandra.yaml
+++ b/helm/cassandra/templates/cassandra.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-  imagePullPolicy: {{ .Values.imagePullPolicy }}
+  imagePullPolicy: {{ .Values.image.pullPolicy }}
   resources:
 {{ toYaml .Values.resources | indent 4 }}
   dataVolumeClaim:

--- a/helm/cassandra/values.yaml
+++ b/helm/cassandra/values.yaml
@@ -7,8 +7,7 @@ replicaCount: 3
 image:
   repository: gcr.io/cassandra-operator/cassandra-dev
   tag: latest
-
-imagePullPolicy: Never
+  pullPolicy: Always
 
 resources:
   limits:


### PR DESCRIPTION
The issues I've been experiencing with helm appear to have been an old cached Docker image. Adding the following changes made the helm packages install the latest version correctly, moving past the issue.