### PR TITLE
Prometheus

### DIFF
--- a/docker/cassandra/install-cassandra
+++ b/docker/cassandra/install-cassandra
@@ -37,6 +37,11 @@ mkdir /etc/cassandra/cassandra-env.sh.d
 mkdir /etc/cassandra/jvm.options.d
 mkdir /etc/cassandra/logback.xml.d
 
+# install cassandra-exporter (Prometheus monitoring support)
+(cd "/usr/share/cassandra/agents" &&
+    curl -SLO "https://github.com/zegelin/cassandra-exporter/releases/download/v0.9.0/cassandra-exporter-agent-0.9.0.jar" &&
+    ln -s cassandra-exporter-agent-0.9.0.jar cassandra-exporter-agent.jar)
+
 # clean-up
 rm -rf "${pkg_dir}"
 apt-get -y remove dpkg-dev && apt-get -y autoremove

--- a/docker/cassandra/install-cassandra
+++ b/docker/cassandra/install-cassandra
@@ -39,8 +39,8 @@ mkdir /etc/cassandra/logback.xml.d
 
 # install cassandra-exporter (Prometheus monitoring support)
 (cd "/usr/share/cassandra/agents" &&
-    curl -SLO "https://github.com/zegelin/cassandra-exporter/releases/download/v0.9.0/cassandra-exporter-agent-0.9.0.jar" &&
-    ln -s cassandra-exporter-agent-0.9.0.jar cassandra-exporter-agent.jar)
+    curl -SLO "https://github.com/zegelin/cassandra-exporter/releases/download/v0.9.2/cassandra-exporter-agent-0.9.2.jar" &&
+    ln -s cassandra-exporter-agent-0.9.2.jar cassandra-exporter-agent.jar)
 
 # clean-up
 rm -rf "${pkg_dir}"

--- a/java/model/src/main/resources/schema/CassandraDataCenter.json
+++ b/java/model/src/main/resources/schema/CassandraDataCenter.json
@@ -64,6 +64,11 @@
         "prometheusSupport": {
           "type": "boolean",
           "description": "Enable Prometheus support."
+        },
+        "prometheusServiceMonitorLabels": {
+          "type": "object",
+          "javaType": "java.util.Map<String, String>",
+          "description": "Labels to attach to the Prometheus ServiceMonitor for this data center."
         }
       }
     }

--- a/java/model/src/main/resources/schema/CassandraDataCenter.json
+++ b/java/model/src/main/resources/schema/CassandraDataCenter.json
@@ -60,6 +60,10 @@
           "type": "object",
           "javaType": "io.kubernetes.client.models.V1ConfigMapVolumeSource",
           "description" : "Name of an optional config map that contains cassandra configuration in the form of yaml fragments"
+        },
+        "prometheusSupport": {
+          "type": "boolean",
+          "description": "Enable Prometheus support."
         }
       }
     }


### PR DESCRIPTION
This is a branch off `controller-refactor`, hence length of this PR and the duplicate commits & changes.

Things of note:

- New DataCenter CRD fields: `prometheusSupport` (boolean) and `prometheusServiceMonitorLabels` (label key pairs).
- Embedding of the cassandra-exporter Java agent into the Cassandra image.
- Reconcilliation controller optionally enables the exporter agent, exposes the required ports (9500) & creates the `ServiceMonitor` object (part of _prometheus-operator_).