### PR TITLE
change prometheus support variable to correct name

### DIFF
--- a/examples/common/test.yaml
+++ b/examples/common/test.yaml
@@ -19,4 +19,4 @@ spec:
       requests:
         storage: 100Mi
   privilegedSupported: true
-  prometheusEnabled: false
+  prometheusSupport: false


### PR DESCRIPTION
First of all, compliments for the cool initiative with cassandra-operator!

I tried deploying the test.yaml and found out that there is a misconfigured variable (possible due to not updating it to the new name). The correct variable name seems to be: `prometheusSupport`