### PR TITLE
Feature/pullsecret support

### DIFF
--- a/buildenv/release
+++ b/buildenv/release
@@ -6,7 +6,9 @@ set -o nounset
 set -o pipefail
 
 function defer {
-	docker logout gcr.io
+	if [[ $REPO == gcr.io/* ]]; then
+		docker logout gcr.io
+	fi
 }
 
 if [[ "${DONT_LOGIN}" != "true" ]]; then

--- a/buildenv/release-all
+++ b/buildenv/release-all
@@ -7,13 +7,17 @@ set -o pipefail
 cd `dirname "$BASH_SOURCE"`/..
 
 function defer {
-	docker logout gcr.io
-	export DONT_LOGIN="false"
+	if [[ $REPO == gcr.io/* ]]; then
+		docker logout gcr.io
+		export DONT_LOGIN="false"
+	fi
 }
 
 trap defer EXIT
 
-gcloud docker -a
+if [[ $REPO == gcr.io/* ]]; then
+	gcloud docker -a
+fi
 
 export DONT_LOGIN="true"
 

--- a/helm/cassandra-operator/templates/deployment.yaml
+++ b/helm/cassandra-operator/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
 #          Uncomment and modify to change operator behaviour via start up flags
           command: ["java"]
-          args: ["-jar", "/opt/lib/cassandra-operator/cassandra-operator.jar", "--namespace=craig"]
+          args: ["-jar", "/opt/lib/cassandra-operator/cassandra-operator.jar", "--no-version-check=false"]
           ports:
             - containerPort: 8080
               name: http

--- a/helm/cassandra-operator/templates/deployment.yaml
+++ b/helm/cassandra-operator/templates/deployment.yaml
@@ -26,8 +26,8 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
 #          Uncomment and modify to change operator behaviour via start up flags
-          command: ["java"]
-          args: ["-jar", "/opt/lib/cassandra-operator/cassandra-operator.jar", "--no-version-check=false"]
+#          command: ["java"]
+#          args: ["-jar", "/opt/lib/cassandra-operator/cassandra-operator.jar", "--no-version-check=false"]
           ports:
             - containerPort: 8080
               name: http

--- a/helm/cassandra-operator/templates/deployment.yaml
+++ b/helm/cassandra-operator/templates/deployment.yaml
@@ -17,6 +17,10 @@ spec:
         operator: cassandra
         release: {{ .Release.Name }}
     spec:
+      {{- with .Values.pullSecret }}
+      imagePullSecrets:
+        - name: {{ . }}
+      {{- end }}
       containers:
         - name: {{ template "cassandra-operator.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm/cassandra-operator/templates/deployment.yaml
+++ b/helm/cassandra-operator/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -17,7 +17,7 @@ spec:
         operator: cassandra
         release: {{ .Release.Name }}
     spec:
-      {{- with .Values.pullSecret }}
+      {{- with .Values.imagePullSecret }}
       imagePullSecrets:
         - name: {{ . }}
       {{- end }}
@@ -26,8 +26,8 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
 #          Uncomment and modify to change operator behaviour via start up flags
-#          command: ["java"]
-#          args: ["-jar", "/opt/lib/cassandra-operator/cassandra-operator.jar", "--no-version-check=false"]
+          command: ["java"]
+          args: ["-jar", "/opt/lib/cassandra-operator/cassandra-operator.jar", "--namespace=craig"]
           ports:
             - containerPort: 8080
               name: http

--- a/helm/cassandra/templates/cassandra.yaml
+++ b/helm/cassandra/templates/cassandra.yaml
@@ -15,10 +15,7 @@ spec:
   cassandraImage: "{{ .Values.image.cassandraRepository }}:{{ .Values.image.cassandraTag }}"
   sidecarImage: "{{ .Values.image.sidecarRepository }}:{{ .Values.image.sidecarTag }}"
   imagePullPolicy: {{ .Values.imagePullPolicy }}
-{{- with .Values.imagePullSecret }}
-  imagePullSecrets:
-    - name: {{ . }}
-{{- end }}
+  imagePullSecret: {{ .Values.imagePullSecret }}
   resources:
 {{ toYaml .Values.resources | indent 4 }}
   dataVolumeClaim:

--- a/helm/cassandra/templates/cassandra.yaml
+++ b/helm/cassandra/templates/cassandra.yaml
@@ -15,7 +15,7 @@ spec:
   cassandraImage: "{{ .Values.image.cassandraRepository }}:{{ .Values.image.cassandraTag }}"
   sidecarImage: "{{ .Values.image.sidecarRepository }}:{{ .Values.image.sidecarTag }}"
   imagePullPolicy: {{ .Values.imagePullPolicy }}
-  imagePullSecret: {{ default "" .Values.imagePullSecret }}
+  imagePullSecret: {{ .Values.imagePullSecret }}
   resources:
 {{ toYaml .Values.resources | indent 4 }}
   dataVolumeClaim:

--- a/helm/cassandra/templates/cassandra.yaml
+++ b/helm/cassandra/templates/cassandra.yaml
@@ -15,7 +15,10 @@ spec:
   cassandraImage: "{{ .Values.image.cassandraRepository }}:{{ .Values.image.cassandraTag }}"
   sidecarImage: "{{ .Values.image.sidecarRepository }}:{{ .Values.image.sidecarTag }}"
   imagePullPolicy: {{ .Values.imagePullPolicy }}
-  imagePullSecret: {{ .Values.imagePullSecret }}
+{{- with .Values.imagePullSecret }}
+  imagePullSecrets:
+    - name: {{ . }}
+{{- end }}
   resources:
 {{ toYaml .Values.resources | indent 4 }}
   dataVolumeClaim:

--- a/helm/cassandra/templates/cassandra.yaml
+++ b/helm/cassandra/templates/cassandra.yaml
@@ -15,6 +15,7 @@ spec:
   cassandraImage: "{{ .Values.image.cassandraRepository }}:{{ .Values.image.cassandraTag }}"
   sidecarImage: "{{ .Values.image.sidecarRepository }}:{{ .Values.image.sidecarTag }}"
   imagePullPolicy: {{ .Values.imagePullPolicy }}
+  imagePullSecret: {{ default "" .Values.imagePullSecret }}
   resources:
 {{ toYaml .Values.resources | indent 4 }}
   dataVolumeClaim:

--- a/helm/cassandra/values.yaml
+++ b/helm/cassandra/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 3
 
 image:
-  cassandraRepository: gcr.io/cassandra-operator/cassandra
+  cassandraRepository: gcr.io/cassandra-operator/cassandra-dev
   sidecarRepository: gcr.io/cassandra-operator/cassandra-sidecar-dev
   cassandraTag: 3.11.3
   sidecarTag: latest

--- a/helm/cassandra/values.yaml
+++ b/helm/cassandra/values.yaml
@@ -16,9 +16,9 @@ privilegedSupported: true
 
 resources:
   limits:
-    memory: 1024Mi
+    memory: 512Mi
   requests:
-    memory: 1024Mi
+    memory: 512Mi
 dataVolumeClaim:
   accessModes:
     - ReadWriteOnce

--- a/helm/cassandra/values.yaml
+++ b/helm/cassandra/values.yaml
@@ -11,15 +11,14 @@ image:
   sidecarTag: latest
 
 imagePullPolicy: IfNotPresent
-imagePullSecret: ""
 
 privilegedSupported: true
 
 resources:
   limits:
-    memory: 512Mi
+    memory: 1024Mi
   requests:
-    memory: 512Mi
+    memory: 1024Mi
 dataVolumeClaim:
   accessModes:
     - ReadWriteOnce

--- a/helm/cassandra/values.yaml
+++ b/helm/cassandra/values.yaml
@@ -11,6 +11,7 @@ image:
   sidecarTag: latest
 
 imagePullPolicy: IfNotPresent
+imagePullSecret: ""
 
 privilegedSupported: true
 

--- a/helm/cassandra/values.yaml
+++ b/helm/cassandra/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 3
 
 image:
-  cassandraRepository: gcr.io/cassandra-operator/cassandra-dev
+  cassandraRepository: gcr.io/cassandra-operator/cassandra
   sidecarRepository: gcr.io/cassandra-operator/cassandra-sidecar-dev
   cassandraTag: 3.11.3
   sidecarTag: latest

--- a/java/model/src/main/resources/schema/CassandraDataCenter.json
+++ b/java/model/src/main/resources/schema/CassandraDataCenter.json
@@ -35,6 +35,9 @@
         "imagePullPolicy" : {
           "type": "string"
         },
+        "imagePullSecret" : {
+          "type": "string"
+        },
         "env" : {
           "description": "List of environment variables to inject in the Cassandra & Sidecar container.",
           "type": "array",

--- a/java/operator/src/main/java/com/instaclustr/cassandra/operator/controller/DataCenterReconciliationController.java
+++ b/java/operator/src/main/java/com/instaclustr/cassandra/operator/controller/DataCenterReconciliationController.java
@@ -116,6 +116,17 @@ public class DataCenterReconciliationController {
         }
     }
 
+    private V1PodSpec createPodSpec() {
+        V1PodSpec podSpec = new V1PodSpec();
+        String secret = dataCenterSpec.getImagePullSecret();
+        if (secret != null && secret.length() > 0) {
+            V1LocalObjectReference pullSecret = new V1LocalObjectReference();
+            pullSecret.setName(dataCenterSpec.getImagePullSecret());
+            podSpec.addImagePullSecretsItem(pullSecret);
+        }
+        return podSpec;
+    }
+
     private void createOrReplaceStateNodesStatefulSet(final Iterable<ConfigMapVolumeMount> configMapVolumeMounts, final V1SecretVolumeSource secretVolumeSource) throws ApiException {
         final V1Container cassandraContainer = new V1Container()
                 .name("cassandra")
@@ -160,7 +171,7 @@ public class DataCenterReconciliationController {
                 );
 
 
-        final V1PodSpec podSpec = new V1PodSpec()
+        final V1PodSpec podSpec = createPodSpec()
                 .addInitContainersItem(fileLimitInit())
                 .addContainersItem(cassandraContainer)
                 .addContainersItem(sidecarContainer)

--- a/java/operator/src/main/java/com/instaclustr/cassandra/operator/controller/DataCenterReconciliationController.java
+++ b/java/operator/src/main/java/com/instaclustr/cassandra/operator/controller/DataCenterReconciliationController.java
@@ -117,10 +117,6 @@ public class DataCenterReconciliationController {
         }
     }
 
-    private V1PodSpec createPodSpec() {
-        return podSpec;
-    }
-
     private void createOrReplaceStateNodesStatefulSet(final Iterable<ConfigMapVolumeMount> configMapVolumeMounts, final V1SecretVolumeSource secretVolumeSource) throws ApiException {
         final V1Container cassandraContainer = new V1Container()
                 .name("cassandra")

--- a/java/operator/src/main/java/com/instaclustr/cassandra/operator/controller/DataCenterReconciliationController.java
+++ b/java/operator/src/main/java/com/instaclustr/cassandra/operator/controller/DataCenterReconciliationController.java
@@ -1,5 +1,6 @@
 package com.instaclustr.cassandra.operator.controller;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.*;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
@@ -117,13 +118,6 @@ public class DataCenterReconciliationController {
     }
 
     private V1PodSpec createPodSpec() {
-        V1PodSpec podSpec = new V1PodSpec();
-        String secret = dataCenterSpec.getImagePullSecret();
-        if (secret != null && secret.length() > 0) {
-            V1LocalObjectReference pullSecret = new V1LocalObjectReference();
-            pullSecret.setName(dataCenterSpec.getImagePullSecret());
-            podSpec.addImagePullSecretsItem(pullSecret);
-        }
         return podSpec;
     }
 
@@ -170,8 +164,7 @@ public class DataCenterReconciliationController {
                         .mountPath("/var/lib/cassandra")
                 );
 
-
-        final V1PodSpec podSpec = createPodSpec()
+        final V1PodSpec podSpec = new V1PodSpec()
                 .addInitContainersItem(fileLimitInit())
                 .addContainersItem(cassandraContainer)
                 .addContainersItem(sidecarContainer)
@@ -197,7 +190,12 @@ public class DataCenterReconciliationController {
                         )
                 );
 
-
+        final String secret = dataCenterSpec.getImagePullSecret();
+        if (!Strings.isNullOrEmpty(secret)) {
+            final V1LocalObjectReference pullSecret = new V1LocalObjectReference();
+            pullSecret.setName(dataCenterSpec.getImagePullSecret());
+            podSpec.addImagePullSecretsItem(pullSecret);
+        }
 
         // add configmap volumes
         for (final ConfigMapVolumeMount configMapVolumeMount : configMapVolumeMounts) {

--- a/java/operator/src/main/resources/com/instaclustr/datacenter-crd.yaml
+++ b/java/operator/src/main/resources/com/instaclustr/datacenter-crd.yaml
@@ -29,6 +29,7 @@ spec:
           - cassandraImage
           - sidecarImage
           - imagePullPolicy
+          - imagePullSecret
           - prometheusSupport
           - privilegedSupported
           properties:
@@ -53,7 +54,7 @@ spec:
               description: Valid values are "Never" "Always" "IfNotPresent".
             imagePullSecret:
               type: string
-              description: Container registry pull secret.
+              description: Container registry pull secret. Can be "".
             resources:
               type: object
               description: the cpu & memory to construct pod.

--- a/java/operator/src/main/resources/com/instaclustr/datacenter-crd.yaml
+++ b/java/operator/src/main/resources/com/instaclustr/datacenter-crd.yaml
@@ -29,7 +29,6 @@ spec:
           - cassandraImage
           - sidecarImage
           - imagePullPolicy
-          - imagePullSecret
           - prometheusSupport
           - privilegedSupported
           properties:

--- a/java/operator/src/main/resources/com/instaclustr/datacenter-crd.yaml
+++ b/java/operator/src/main/resources/com/instaclustr/datacenter-crd.yaml
@@ -29,6 +29,7 @@ spec:
           - cassandraImage
           - sidecarImage
           - imagePullPolicy
+          - imagePullSecret
           - prometheusSupport
           - privilegedSupported
           properties:
@@ -51,6 +52,9 @@ spec:
             imagePullPolicy:
               type: string
               description: Valid values are "Never" "Always" "IfNotPresent".
+            imagePullSecret:
+              type: string
+              description: Container registry pull secret.
             resources:
               type: object
               description: the cpu & memory to construct pod.


### PR DESCRIPTION
This not only makes it so the operator sets up the imagePullSecret properly, but it also allows the build/release scripts to work outside of `gcloud`. I'm simply exporting `REPO=myreponame/mynamespace` and `DONT_LOGIN=true` before running build/release commands.

Resolves #126