### PR TITLE
Fix release-all

### DIFF
--- a/buildenv/release-all
+++ b/buildenv/release-all
@@ -15,9 +15,6 @@ function defer {
 
 trap defer EXIT
 
-if [[ $REPO == gcr.io/* ]]; then
-	gcloud docker -a
-fi
 
 export DONT_LOGIN="true"
 


### PR DESCRIPTION
I don't think we need to login on release-all as the individual release script calls it