### PR TITLE
Fix deployment support for helm chart

### DIFF
--- a/helm/cassandra-operator/templates/deployment.yaml
+++ b/helm/cassandra-operator/templates/deployment.yaml
@@ -10,6 +10,11 @@ metadata:
   name: {{ template "cassandra-operator.fullname" . }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "cassandra-operator.name" . }}
+      operator: cassandra
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
extensions/v1beta1 Deployments had the selector field as optional, but not apps/v1 Deployments. Upgrading to support new versions