### PR TITLE
Increase Memory limits for Cassandra operator

### DIFF
--- a/examples/common/bundle.yaml
+++ b/examples/common/bundle.yaml
@@ -23,7 +23,7 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 100Mi
+            memory: 300Mi
           requests:
             cpu: 100m
             memory: 50Mi

--- a/examples/common/rbac-bundle.yaml
+++ b/examples/common/rbac-bundle.yaml
@@ -99,7 +99,7 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 100Mi
+            memory: 300Mi
           requests:
             cpu: 100m
             memory: 50Mi

--- a/helm/cassandra-operator/values.yaml
+++ b/helm/cassandra-operator/values.yaml
@@ -15,7 +15,7 @@ resources: {}
   # Suggested resource limits for the operator itself (not cassandra), works with a reasonable sized minikube.
 #  limits:
 #    cpu: 200m
-#    memory: 100Mi
+#    memory: 300Mi
 #  requests:
 #    cpu: 100m
 #    memory: 50Mi

--- a/test/k8s/bundle-template.yaml
+++ b/test/k8s/bundle-template.yaml
@@ -86,7 +86,7 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 100Mi
+            memory: 300Mi
           requests:
             cpu: 100m
             memory: 50Mi


### PR DESCRIPTION
When running Cassandra Operator, I get lots of OOM killed events in OpenShift. Because of this, memory limits for operator is changed to 300Mi.

Fixes #145