### PR TITLE
Add conditional in Makefiles in order to use other image builders

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,0 +1,1 @@
+BUILD_COMMAND ?= "docker build"

--- a/docker/base-openjre/Makefile
+++ b/docker/base-openjre/Makefile
@@ -1,10 +1,12 @@
+include ../../Makefile.inc
+
 OPENJRE_VERSION := "8u212-b01-1~deb9u1"
 OPENJRE_IMAGE_TAG := stretch-$(subst ~,-,$(OPENJRE_VERSION))
 OPENJRE_IMAGE := $(DOCKER_REPO)base-openjre:$(OPENJRE_IMAGE_TAG)
 
 .PHONY: base-openjre
 base-openjre:
-	docker build \
+	$(BUILD_COMMAND) \
 		--build-arg openjre_version=$(OPENJRE_VERSION) \
 		-t $(DOCKER_REPO)base-openjre \
 		-t $(OPENJRE_IMAGE) \

--- a/docker/cassandra-operator/Makefile
+++ b/docker/cassandra-operator/Makefile
@@ -13,7 +13,7 @@ $(CASSANDRA_OPERATOR_JAR):
 	
 .PHONY: cassandra-operator
 cassandra-operator: $(CASSANDRA_OPERATOR_JAR)
-	docker build \
+	$(BUILD_COMMAND) \
 		--build-arg cassandra_operator_jar=$(CASSANDRA_OPERATOR_JAR) \
 		--build-arg openjre_image="$(OPENJRE_IMAGE)" \
 		-t $(DOCKER_REPO)cassandra-operator \

--- a/docker/cassandra-sidecar/Makefile
+++ b/docker/cassandra-sidecar/Makefile
@@ -14,7 +14,7 @@ $(CASSANDRA_SIDECAR_JAR):
 	
 .PHONY: cassandra-sidecar
 cassandra-sidecar: $(CASSANDRA_SIDECAR_JAR)
-	docker build \
+	$(BUILD_COMMAND) \
 		--build-arg cassandra_sidecar_jar=$(CASSANDRA_SIDECAR_JAR) \
 		--build-arg openjre_image="$(OPENJRE_IMAGE)" \
 		-t $(DOCKER_REPO)cassandra-sidecar \

--- a/docker/cassandra/Makefile
+++ b/docker/cassandra/Makefile
@@ -16,16 +16,15 @@ endif
 $(CASSANDRA_K8S_ADDONS_JAR):
 	mvn dependency:copy -Dartifact=com.instaclustr.cassandra-operator:cassandra-k8s-addons:$(CASSANDRA_K8S_ADDONS_VERSION) -DoutputDirectory=. -Dmdep.stripClassifier=true
 
-
 # Cassandra
 .PHONY: cassandra
 cassandra: $(CASSANDRA_K8S_ADDONS_JAR)
-	docker build \
+	$(BUILD_COMMAND) \
 		--build-arg cassandra_version=$(CASSANDRA_VERSION) \
 		--build-arg cassandra_k8s_addons_jar=$(CASSANDRA_K8S_ADDONS_JAR) \
 		--build-arg openjre_image="$(OPENJRE_IMAGE)" \
-		-t $(DOCKER_REPO)cassandra \
-		-t $(DOCKER_REPO)cassandra:$(CASSANDRA_VERSION) \
+		-t $(DOCKER_REPO)/cassandra \
+		-t $(DOCKER_REPO)/cassandra:$(CASSANDRA_VERSION) \
 		.
 
 


### PR DESCRIPTION
My Fedora uses [Buildah](https://buildah.io/) to build images with parameters. Because of that, I decided to add some conditionals to look for buildah in the path and run it instead of docker if present.

Fixes #147