### PR TITLE
Update Cassandra image to include LDAP and Kerberos plugins.

### DIFF
--- a/buildenv/build-all
+++ b/buildenv/build-all
@@ -3,7 +3,7 @@
 
 cd `dirname "$BASH_SOURCE"`/..
 
-export DOCKER_REPO="${REPO:-gcr.io/cassandra-operator}"
+export DOCKER_REPO="${REPO:-gcr.io/cassandra-operator}/"
 
 cd docker
 make

--- a/docker/base-openjre/Makefile
+++ b/docker/base-openjre/Makefile
@@ -1,12 +1,12 @@
 OPENJRE_VERSION := "8u181-b13-2~deb9u1"
 OPENJRE_IMAGE_TAG := stretch-$(subst ~,-,$(OPENJRE_VERSION))
-OPENJRE_IMAGE := $(DOCKER_REPO)/base-openjre:$(OPENJRE_IMAGE_TAG)
+OPENJRE_IMAGE := $(DOCKER_REPO)base-openjre:$(OPENJRE_IMAGE_TAG)
 
 .PHONY: base-openjre
 base-openjre:
 	docker build \
 		--build-arg openjre_version=$(OPENJRE_VERSION) \
-		-t $(DOCKER_REPO)/base-openjre \
+		-t $(DOCKER_REPO)base-openjre \
 		-t $(OPENJRE_IMAGE) \
 		.
 

--- a/docker/cassandra-operator/Makefile
+++ b/docker/cassandra-operator/Makefile
@@ -16,8 +16,8 @@ cassandra-operator: $(CASSANDRA_OPERATOR_JAR)
 	docker build \
 		--build-arg cassandra_operator_jar=$(CASSANDRA_OPERATOR_JAR) \
 		--build-arg openjre_image="$(OPENJRE_IMAGE)" \
-		-t $(DOCKER_REPO)/cassandra-operator \
-		-t $(DOCKER_REPO)/cassandra-operator:$(CASSANDRA_OPERATOR_VERSION) \
+		-t $(DOCKER_REPO)cassandra-operator \
+		-t $(DOCKER_REPO)cassandra-operator:$(CASSANDRA_OPERATOR_VERSION) \
 		.
 
 .PHONY: clean

--- a/docker/cassandra-sidecar/Makefile
+++ b/docker/cassandra-sidecar/Makefile
@@ -4,7 +4,8 @@ CASSANDRA_SIDECAR_VERSION := 1.0-SNAPSHOT
 CASSANDRA_SIDECAR_JAR := cassandra-sidecar-$(CASSANDRA_SIDECAR_VERSION).jar
 
 ifeq ($(CASSANDRA_SIDECAR_VERSION:%-SNAPSHOT=SNAPSHOT),SNAPSHOT)
-$(info SNAPSHOT version specified. Marking JAR target as .PHONY)
+# mark sidecar-jar target as .PHONY to force a re-copy on every build
+$(info cassandra-sidecar SNAPSHOT version specified ($(CASSANDRA_SIDECAR_VERSION)). Marking JAR target as .PHONY. This will re-download the artifact.)
 .PHONY: $(CASSANDRA_SIDECAR_JAR)
 endif
 
@@ -16,8 +17,8 @@ cassandra-sidecar: $(CASSANDRA_SIDECAR_JAR)
 	docker build \
 		--build-arg cassandra_sidecar_jar=$(CASSANDRA_SIDECAR_JAR) \
 		--build-arg openjre_image="$(OPENJRE_IMAGE)" \
-		-t $(DOCKER_REPO)/cassandra-sidecar \
-		-t $(DOCKER_REPO)/cassandra-sidecar:$(CASSANDRA_SIDECAR_VERSION) \
+		-t $(DOCKER_REPO)cassandra-sidecar \
+		-t $(DOCKER_REPO)cassandra-sidecar:$(CASSANDRA_SIDECAR_VERSION) \
 		.
 
 .PHONY: clean

--- a/docker/cassandra/Makefile
+++ b/docker/cassandra/Makefile
@@ -5,23 +5,29 @@ CASSANDRA_VERSION := 3.11.3
 CASSANDRA_K8S_ADDONS_VERSION := 1.0-SNAPSHOT
 CASSANDRA_K8S_ADDONS_JAR := cassandra-k8s-addons-$(CASSANDRA_K8S_ADDONS_VERSION).jar
 
+
+# Cassandra/K8s Addons
 ifeq ($(CASSANDRA_K8S_ADDONS_VERSION:%-SNAPSHOT=SNAPSHOT),SNAPSHOT)
-$(info SNAPSHOT version specified. Marking JAR target as .PHONY)
+# mark addons-jar target as .PHONY to force a re-copy on every build
+$(info cassandra-k8s-addons SNAPSHOT version specified ($(CASSANDRA_K8S_ADDONS_VERSION)). Marking JAR target as .PHONY. This will re-download the artifact.)
 .PHONY: $(CASSANDRA_K8S_ADDONS_JAR)
 endif
 
 $(CASSANDRA_K8S_ADDONS_JAR):
 	mvn dependency:copy -Dartifact=com.instaclustr.cassandra-operator:cassandra-k8s-addons:$(CASSANDRA_K8S_ADDONS_VERSION) -DoutputDirectory=. -Dmdep.stripClassifier=true
-	
+
+
+# Cassandra
 .PHONY: cassandra
 cassandra: $(CASSANDRA_K8S_ADDONS_JAR)
 	docker build \
 		--build-arg cassandra_version=$(CASSANDRA_VERSION) \
 		--build-arg cassandra_k8s_addons_jar=$(CASSANDRA_K8S_ADDONS_JAR) \
 		--build-arg openjre_image="$(OPENJRE_IMAGE)" \
-		-t $(DOCKER_REPO)/cassandra \
-		-t $(DOCKER_REPO)/cassandra:$(CASSANDRA_VERSION) \
+		-t $(DOCKER_REPO)cassandra \
+		-t $(DOCKER_REPO)cassandra:$(CASSANDRA_VERSION) \
 		.
+
 
 .PHONY: clean
 clean:

--- a/docker/cassandra/install-cassandra
+++ b/docker/cassandra/install-cassandra
@@ -1,6 +1,26 @@
 #!/bin/bash -xue
 
+echoerr() { >&2 echo $@; }
+
 cassandra_version=$1
+
+case $cassandra_version in
+3.*)
+    # supported
+    ;;
+
+2.*)
+    # 2.2 pulls in openjre, which pulls in gtk, x11, etc.
+    # also, the default-config is specific to 3.11.x.
+    # 2.2 fails to start due to unrecognised YAML properties.
+
+    # no k8s addons support, yet.
+    ;&
+
+*)
+    echoerr "WARNING: Cassandra version ${cassandra_version} is unsupported."
+    exit 1;
+esac
 
 adduser --disabled-password --gid 0 --gecos "Cassandra" cassandra
 
@@ -44,10 +64,12 @@ mkdir /etc/cassandra/logback.xml.d
 
 # install Instaclustr LDAP and Kerberos authn/authz plugins
 (
-    cd "/usr/share/cassandra/lib" &&
+    cd "/usr/share/cassandra/lib"
+
+    # TODO: switch remaining Maven Central URLs to GitHub.
     case ${cassandra_version} in
     3.11.*)
-        curl -SLO "https://search.maven.org/remotecontent?filepath=com/instaclustr/cassandra-ldap/3.11.4.4/cassandra-ldap-3.11.4.4.jar"
+        curl -SLO "https://github.com/instaclustr/cassandra-ldap/releases/download/3.11.4.4/cassandra-ldap-3.11.4.jar"
         ;;
     3.0.*)
         curl -SLO "https://search.maven.org/remotecontent?filepath=com/instaclustr/cassandra-ldap/3.0.18.0/cassandra-ldap-3.0.18.0.jar"
@@ -56,10 +78,23 @@ mkdir /etc/cassandra/logback.xml.d
         curl -SLO "https://search.maven.org/remotecontent?filepath=com/instaclustr/cassandra-ldap/2.2.14.0/cassandra-ldap-2.2.14.jar"
         ;;
     *)
-        echo "Warning: No LDAP plugin available for Cassandra version ${cassandra_version}."
+        echoerr "WARNING: No LDAP plugin available for Cassandra version ${cassandra_version}. This feature will be unavailable."
+        ;;
+    esac
+
+    case ${cassandra_version} in
+    3.11.*)
+        curl -SLO "https://github.com/instaclustr/cassandra-kerberos/releases/download/v1.0.0-cassandra-3.11/cassandra-3-11-kerberos-1.0.0.jar"
+        ;;
+    3.0.*)
+        curl -SLO "https://github.com/instaclustr/cassandra-kerberos/releases/download/v1.0.0-cassandra-3.0/cassandra-3-0-kerberos-1.0.0.jar"
+        ;;
+    *)
+        echoerr "WARNING: No Kerberos plugin available for Cassandra version ${cassandra_version}. This feature will be unavailable."
         ;;
     esac
 )
+
 
 # clean-up
 rm -rf "${pkg_dir}"

--- a/docker/cassandra/install-cassandra
+++ b/docker/cassandra/install-cassandra
@@ -42,6 +42,25 @@ mkdir /etc/cassandra/logback.xml.d
     curl -SLO "https://github.com/instaclustr/cassandra-exporter/releases/download/v0.9.6/cassandra-exporter-agent-0.9.6.jar" &&
     ln -s cassandra-exporter-agent-0.9.6.jar cassandra-exporter-agent.jar)
 
+# install Instaclustr LDAP and Kerberos authn/authz plugins
+(
+    cd "/usr/share/cassandra/lib" &&
+    case ${cassandra_version} in
+    3.11.*)
+        curl -SLO "https://search.maven.org/remotecontent?filepath=com/instaclustr/cassandra-ldap/3.11.4.4/cassandra-ldap-3.11.4.4.jar"
+        ;;
+    3.0.*)
+        curl -SLO "https://search.maven.org/remotecontent?filepath=com/instaclustr/cassandra-ldap/3.0.18.0/cassandra-ldap-3.0.18.0.jar"
+        ;;
+    2.2.*)
+        curl -SLO "https://search.maven.org/remotecontent?filepath=com/instaclustr/cassandra-ldap/2.2.14.0/cassandra-ldap-2.2.14.jar"
+        ;;
+    *)
+        echo "Warning: No LDAP plugin available for Cassandra version ${cassandra_version}."
+        ;;
+    esac
+)
+
 # clean-up
 rm -rf "${pkg_dir}"
 apt-get -y remove dpkg-dev && apt-get -y autoremove


### PR DESCRIPTION
Also enables repository-less Docker builds (i.e., on a local machine)