### PR TITLE
Backup/restore improvements 

### DIFF
--- a/doc/backup_restore.md
+++ b/doc/backup_restore.md
@@ -174,7 +174,7 @@ spec:
       secretKeyRef:
         name: azure-storage
         key: accountName
-  - name: AZURE_STORAGE_ACCESS_KEY
+  - name: AZURE_STORAGE_KEY
     valueFrom:
       secretKeyRef:
         name: azure-storage

--- a/doc/backup_restore.md
+++ b/doc/backup_restore.md
@@ -134,9 +134,56 @@ spec:
   prometheusEnabled: false
 ```
 
+## Configuring Azure Storage via environment variables
+
+First create a secret in kubernetes to hold an Azure Storage account name and key (assuming they are stored in files named accountName and accessKey respectively) :
+```
+kubectl create secret generic azure-storage --from-file=./accountName --from-file=./accessKey
+```
+
+Create a `CassandraDataCenter` CRD that mounts the secret in environment variables as follows :
+
+```yaml
+apiVersion: stable.instaclustr.com/v1
+kind: CassandraDataCenter
+metadata:
+  name: foo-cassandra
+  labels:
+    app: cassandra
+    chart: cassandra-0.1.0
+    release: foo
+spec:
+  replicas: 1
+  cassandraImage: "gcr.io/cassandra-operator/cassandra:latest"
+  sidecarImage: "gcr.io/cassandra-operator/cassandra-sidecar:latest"
+  imagePullPolicy: IfNotPresent
+  resources:
+    limits:
+      memory: 512Mi
+    requests:
+      memory: 512Mi
+  dataVolumeClaim:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 100Mi
+  env:
+  - name: AZURE_STORAGE_ACCOUNT
+    valueFrom:
+      secretKeyRef:
+        name: azure-storage
+        key: accountName
+  - name: AZURE_STORAGE_ACCESS_KEY
+    valueFrom:
+      secretKeyRef:
+        name: azure-storage
+        key: accessKey
+```
+
 ## Taking a backup
 The Cassandra-operator manages backups via a backup CRD object in Kubernetes, this makes it easy to track and audit backups, you can schedule backups via a cron mechanism that creates new CRDs etc.
-It also allows you to reference a known backup when you restore. Backups will target all pods that match the labels specified on the backup CRD, you can backup multiple clusters via a single backup CRD. 
+It also allows you to reference a known backup when you restore. Backups will target all pods that match the selector specified on the backup CRD, you can backup multiple clusters via a single backup CRD. 
 Node identitiy is maintained via the backup path.
 
 The name field in metadata will be used as the snapshot name (e.g. via nodetool snapshot and when uploaded to the external storage provider).
@@ -149,12 +196,12 @@ apiVersion: stable.instaclustr.com/v1
 kind: CassandraBackup
 metadata:
   name: backup-hostname
-  labels:
-    cassandra-datacenter: foo-cassandra
 spec:
+  selector:
+    matchLabels:
+      cassandra-operator.instaclustr.com/datacenter: foo-cassandra
   backupType: AWS_S3
   target: kube-backup-test-cassandra
-  status: "PENDING"
 ```
 
 ### GCP
@@ -163,17 +210,32 @@ apiVersion: stable.instaclustr.com/v1
 kind: CassandraBackup
 metadata:
   name: backup-hostname
-  labels:
-    cassandra-datacenter: foo-cassandra
 spec:
+  selector:
+    matchLabels:
+      cassandra-operator.instaclustr.com/datacenter: foo-cassandra
   backupType: GCP_BLOB
   target: ben-cassandra-operator
-  status: "PENDING"
 ```
+
+### Azure
+```yaml
+apiVersion: stable.instaclustr.com/v1
+kind: CassandraBackup
+metadata:
+  name: backup-hostname
+spec:
+  selector:
+    matchLabels:
+      cassandra-operator.instaclustr.com/datacenter: foo-cassandra
+  backupType: AZURE_BLOB
+  target: ben-cassandra-operator
+```
+
 
 In the spec field, `backupType` indicates what storage mechanism to use and `target` will be the undecorated location (e.g. the S3 bucket). To create the backup run `kubectl apply -f backup.yaml`
 
-The Cassandra operator will detect the new backup CRD and take snapshots of all nodes that match the same labels as the `CassandraBackup`. You can follow the progress of the backup by following the sidecar logs for each node included in the backup.
+The Cassandra operator will detect the new backup CRD and take snapshots of all nodes that match the selector. You can follow the progress of the backup by following the sidecar logs for each node included in the backup.
 The backup will include all user data as well as the system/schema tables. This means on restoration your schema will exist.
 
 ## Restoring from a backup
@@ -225,4 +287,4 @@ spec:
 
 The new cluster will download the sstables from the existing backup before starting Cassandra and restore the tokens associated with the node the backup was taken on. The schema will be restored along side the data as well. 
 The operator will match the new clusters nodes to backups from previous cluster based on the ordinal value of the pod assigned by its stateful set (e.g. old-cluster-0 will be restored to new-cluster-0). 
-You should always restore to a cluster with the same number of nodes as the original backup cluster. Restore currently works against just a single DC, if you backup using a broader set of lables, restore from that broader label group won't work.
+You should always restore to a cluster with the same number of nodes and the same name as the original backup cluster. Restore currently works against just a single DC, if you backup using a broader set of labels, restore from that broader label group won't work.

--- a/examples/common/backupCrd.yaml
+++ b/examples/common/backupCrd.yaml
@@ -2,8 +2,9 @@ apiVersion: stable.instaclustr.com/v1
 kind: CassandraBackup
 metadata:
   name: backup-now37
-  labels:
-    cassandra-datacenter: backup3-cassandra
 spec:
+  selector:
+    matchLabels:
+      cassandra-operator.instaclustr.com/datacenter: backup3-cassandra
   backupType: "AWS_S3"
   target: "kube-backup-test-cassandra"

--- a/helm/cassandra/values.yaml
+++ b/helm/cassandra/values.yaml
@@ -17,9 +17,9 @@ privilegedSupported: true
 
 resources:
   limits:
-    memory: 512Mi
+    memory: 1024Mi
   requests:
-    memory: 512Mi
+    memory: 1024Mi
 dataVolumeClaim:
   accessModes:
     - ReadWriteOnce

--- a/java/backup/src/main/java/com/instaclustr/backup/common/CloudDownloadUploadFactory.java
+++ b/java/backup/src/main/java/com/instaclustr/backup/common/CloudDownloadUploadFactory.java
@@ -10,6 +10,7 @@ import com.instaclustr.backup.CommonBackupArguments;
 import com.instaclustr.backup.RestoreArguments;
 import com.instaclustr.backup.downloader.*;
 import com.instaclustr.backup.uploader.*;
+import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.CloudBlobClient;
 
@@ -17,6 +18,7 @@ import javax.naming.ConfigurationException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.InvalidKeyException;
 
 public class CloudDownloadUploadFactory {
 
@@ -33,9 +35,19 @@ public class CloudDownloadUploadFactory {
         return TransferManagerBuilder.defaultTransferManager();
     }
 
-    public static CloudBlobClient getCloudBlobClient() {
-        //TODO: Implement!
-        return null;
+    public static CloudBlobClient getCloudBlobClient() throws URISyntaxException, InvalidKeyException {
+        
+        //TODO: use azure SAS token ?
+        String accountName = System.getenv("AZURE_STORAGE_ACCOUNT");
+        String accessKey = System.getenv("AZURE_STORAGE_ACCESS_KEY");
+        
+        // TODO: what to do when credentials are not specified ?
+        String connectionString = "DefaultEndpointsProtocol=http;"
+                + String.format("AccountName=%s;", accountName)
+                + String.format("AccountKey=%s", accessKey);
+    
+        CloudStorageAccount account = CloudStorageAccount.parse(connectionString);
+        return account.createCloudBlobClient();
     }
 
     public static Storage getGCPStorageClient() {
@@ -49,7 +61,7 @@ public class CloudDownloadUploadFactory {
 
 
 
-    public static SnapshotUploader getUploader(final BackupArguments arguments) throws URISyntaxException, StorageException, ConfigurationException {
+    public static SnapshotUploader getUploader(final BackupArguments arguments) throws URISyntaxException, StorageException, ConfigurationException, InvalidKeyException {
         //final String backupID, final String clusterID, final String backupBucket,
 
         switch (arguments.storageProvider) {
@@ -69,7 +81,7 @@ public class CloudDownloadUploadFactory {
     }
 
 
-    public static Downloader getDownloader(final RestoreArguments arguments) throws URISyntaxException, StorageException, ConfigurationException {
+    public static Downloader getDownloader(final RestoreArguments arguments) throws URISyntaxException, StorageException, ConfigurationException, InvalidKeyException {
         switch (arguments.storageProvider) {
             case AWS_S3:
                 //TODO: support encrypted backups via KMS

--- a/java/backup/src/main/java/com/instaclustr/backup/common/CloudDownloadUploadFactory.java
+++ b/java/backup/src/main/java/com/instaclustr/backup/common/CloudDownloadUploadFactory.java
@@ -38,15 +38,23 @@ public class CloudDownloadUploadFactory {
     public static CloudBlobClient getCloudBlobClient() throws URISyntaxException, InvalidKeyException {
         
         //TODO: use azure SAS token ?
-        String accountName = System.getenv("AZURE_STORAGE_ACCOUNT");
-        String accessKey = System.getenv("AZURE_STORAGE_ACCESS_KEY");
+        
+        // Seems that the azure-storage java SDK does not support credentials discovery. However az cli does support this
+        // so here we try to reproduce the same behavior using AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_KEY
+        final String accountName = System.getenv("AZURE_STORAGE_ACCOUNT");
+        String accessKey = System.getenv("AZURE_STORAGE_KEY");
+        if (accessKey == null) {
+            // az cli also uses AZURE_STORAGE_ACCESS_KEY because of a bug : https://github.com/MicrosoftDocs/azure-docs/issues/14365
+            accessKey = System.getenv("AZURE_STORAGE_ACCESS_KEY");
+        }
+        
         
         // TODO: what to do when credentials are not specified ?
-        String connectionString = "DefaultEndpointsProtocol=http;"
+        final String connectionString = "DefaultEndpointsProtocol=https;"
                 + String.format("AccountName=%s;", accountName)
                 + String.format("AccountKey=%s", accessKey);
     
-        CloudStorageAccount account = CloudStorageAccount.parse(connectionString);
+        final CloudStorageAccount account = CloudStorageAccount.parse(connectionString);
         return account.createCloudBlobClient();
     }
 

--- a/java/backup/src/main/java/com/instaclustr/backup/downloader/AzureDownloader.java
+++ b/java/backup/src/main/java/com/instaclustr/backup/downloader/AzureDownloader.java
@@ -39,7 +39,7 @@ public class AzureDownloader extends Downloader {
     @Override
     public void downloadFile(final Path localPath, final RemoteObjectReference object) throws Exception {
         final CloudBlockBlob blob = ((AzureRemoteObjectReference) object).blob;
-        logger.info(String.format("download file with azure remote_path=%s", blob.getUri()));
+        logger.info("download file with azure remote_path={}", blob.getUri());
         Files.createDirectories(localPath.getParent());
         blob.downloadToFile(localPath.toAbsolutePath().toString());
     }

--- a/java/backup/src/main/java/com/instaclustr/backup/downloader/AzureDownloader.java
+++ b/java/backup/src/main/java/com/instaclustr/backup/downloader/AzureDownloader.java
@@ -27,9 +27,9 @@ public class AzureDownloader extends Downloader {
     public AzureDownloader(final CloudBlobClient cloudBlobClient,
                            final RestoreArguments arguments) throws StorageException, URISyntaxException {
         super(arguments);
-        this.blobContainer = cloudBlobClient.getContainerReference(restoreFromClusterId);
+        this.blobContainer = cloudBlobClient.getContainerReference(restoreFromBackupBucket);
     }
-
+    
     @Override
     public RemoteObjectReference objectKeyToRemoteReference(final Path objectKey) throws StorageException, URISyntaxException {
         final String path = resolveRemotePath(objectKey);
@@ -39,7 +39,8 @@ public class AzureDownloader extends Downloader {
     @Override
     public void downloadFile(final Path localPath, final RemoteObjectReference object) throws Exception {
         final CloudBlockBlob blob = ((AzureRemoteObjectReference) object).blob;
-        Files.createDirectories(localPath);
+        logger.info(String.format("download file with azure remote_path=%s", blob.getUri()));
+        Files.createDirectories(localPath.getParent());
         blob.downloadToFile(localPath.toAbsolutePath().toString());
     }
 

--- a/java/backup/src/main/java/com/instaclustr/backup/task/BackupTask.java
+++ b/java/backup/src/main/java/com/instaclustr/backup/task/BackupTask.java
@@ -30,6 +30,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.InvalidKeyException;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -83,7 +84,7 @@ public class BackupTask implements Callable<Void> {
     }
 
     public BackupTask(final BackupArguments arguments,
-                      final GlobalLock globalLock) throws IOException, StorageException, ConfigurationException, URISyntaxException {
+                      final GlobalLock globalLock) throws IOException, StorageException, ConfigurationException, URISyntaxException, InvalidKeyException {
         this.cassandraJMXServiceURL = arguments.jmxServiceURL;
         this.snapshotManifestDirectory = arguments.sharedContainerPath.resolve(Paths.get("cassandra-operator/manifests"));
         this.snapshotTokensDirectory = arguments.sharedContainerPath.resolve(Paths.get("cassandra-operator/tokens"));

--- a/java/backup/src/main/java/com/instaclustr/backup/uploader/FilesUploader.java
+++ b/java/backup/src/main/java/com/instaclustr/backup/uploader/FilesUploader.java
@@ -24,6 +24,7 @@ import java.net.URISyntaxException;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.security.InvalidKeyException;
 import java.util.Collection;
 import java.util.concurrent.*;
 import java.util.function.Function;
@@ -72,7 +73,7 @@ public class FilesUploader {
         }
     }
 
-    public FilesUploader(final BackupArguments arguments) throws StorageException, ConfigurationException, URISyntaxException {
+    public FilesUploader(final BackupArguments arguments) throws StorageException, ConfigurationException, URISyntaxException, InvalidKeyException {
         this.snapshotUploaderProvider = CloudDownloadUploadFactory.getUploader(arguments);
         this.arguments = arguments;
         this.executorService = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(arguments.concurrentConnections));

--- a/java/model/src/main/java/com/instaclustr/backup/BaseArguments.java
+++ b/java/model/src/main/java/com/instaclustr/backup/BaseArguments.java
@@ -138,9 +138,8 @@ public abstract class BaseArguments {
     @Option(name = "--fl", aliases = {"--filebackup-location"}, usage = "Base directory destination for filesystem based backups", metaVar = "/backups", handler = PathOptionHandler.class)
     @Nullable
     public Path fileBackupDirectory;
-
-    //TODO: Allow user to override commitlog directory (some environments may allow different disks which better suit commitlog performance
-    @Option(name = "--cd", aliases = {"--config-directory"}, usage = "Base directory that contains the Cassandra data, cache and commitlog directories", metaVar = "/cassandra", handler = PathOptionHandler.class)
+    
+    @Option(name = "--cd", aliases = {"--config-directory"}, usage = "Base directory that contains the Cassandra config", metaVar = "/cassandra", handler = PathOptionHandler.class)
     @Nullable
     public Path cassandraConfigDirectory = Paths.get("/etc/cassandra/");
 

--- a/java/model/src/main/resources/schema/CassandraBackup.json
+++ b/java/model/src/main/resources/schema/CassandraBackup.json
@@ -21,13 +21,23 @@
       "javaType": "com.instaclustr.cassandra.operator.model.BackupSpec",
       "type": "object",
       "properties": {
+        "selector": {
+          "type": "object",
+          "javaType": "io.kubernetes.client.models.V1LabelSelector"
+        },
         "backupType" : {
           "type": "string"
         },
         "target" : {
           "type": "string"
-        },
-        "status": {
+        }
+      }
+    },
+    "status": {
+      "javaType": "com.instaclustr.cassandra.operator.model.BackupStatus",
+      "type": "object",
+      "properties": {
+        "progress": {
           "type": "string"
         }
       }

--- a/java/operator/pom.xml
+++ b/java/operator/pom.xml
@@ -86,6 +86,13 @@
         </dependency>
 
 
+        <!-- used by legacy backup code -->
+        <dependency>
+            <groupId>args4j</groupId>
+            <artifactId>args4j</artifactId>
+            <version>2.33</version>
+        </dependency>
+
         <!-- test dependencies -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/java/operator/src/main/resources/com/instaclustr/backup-crd.yaml
+++ b/java/operator/src/main/resources/com/instaclustr/backup-crd.yaml
@@ -26,12 +26,15 @@ spec:
         spec:
           required:
           - backupType
+          - selector
+          - target
           properties:
+            selector:
+              type: object
+              description: match the pods to backup
             backupType:
               type: string
               description: The backup mechanism type e.g. S3, FILE
             target:
               type: string
               description: The uri for the backup target location e.g. s3 bucket, filepath
-            status:
-              type: string

--- a/java/sidecar/src/main/java/com/instaclustr/cassandra/sidecar/resource/BackupsResource.java
+++ b/java/sidecar/src/main/java/com/instaclustr/cassandra/sidecar/resource/BackupsResource.java
@@ -13,6 +13,7 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
 
 @Path("/backups")
 @Produces(MediaType.APPLICATION_JSON)
@@ -28,7 +29,7 @@ public class BackupsResource {
 
 
     @POST
-    public BackupResponse createBackup(BackupArguments backupArguments) throws URISyntaxException, StorageException, ConfigurationException, IOException {
+    public BackupResponse createBackup(BackupArguments backupArguments) throws URISyntaxException, StorageException, ConfigurationException, IOException, InvalidKeyException {
         logger.info("received backup request for {}", backupArguments.backupId);
         backupService.enqueueBackup(backupArguments);
         logger.info("enqueued backup request for {}", backupArguments.backupId);

--- a/java/sidecar/src/main/java/com/instaclustr/cassandra/sidecar/service/backup/BackupService.java
+++ b/java/sidecar/src/main/java/com/instaclustr/cassandra/sidecar/service/backup/BackupService.java
@@ -9,13 +9,14 @@ import com.microsoft.azure.storage.StorageException;
 import javax.naming.ConfigurationException;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class BackupService extends AbstractIdleService {
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
-    public void enqueueBackup(final BackupArguments arguments) throws IOException, StorageException, ConfigurationException, URISyntaxException {
+    public void enqueueBackup(final BackupArguments arguments) throws IOException, StorageException, ConfigurationException, URISyntaxException, InvalidKeyException {
         final BackupTask backupTask = new BackupTask(arguments, new GlobalLock("/tmp"));
 
         executorService.submit(backupTask);


### PR DESCRIPTION
Hello,

Here is the PR that fixes the issues discussed in #152.

What changed :
* an emptydir shared volume mounted at  `/tmp/sidecar-volume-config` by both sidecars and cassandra containers
  * restore sidecar writes a fragment config to /tmp/sidecar-volume-config with intial_token and auto_bootstrap disabled.
  * cassandra config loader uses /tmp/sidecar-volume-config 
* the operator now set `backup.status.progress` rather than `backup.spec.status`
* basic Azure Storage support (which I used for testing)
* the pods to backup are selected using a `backup.spec.selector` rather than `backup.metadata.labels`
* documentation update
* some fixes

Works on my machine with Azure Storage !
