### PR TITLE
Fixes incorrect label selector on StatefulSet and ConfigMaps

### DIFF
--- a/java/operator/src/main/java/com/instaclustr/cassandra/operator/controller/DataCenterDeletionController.java
+++ b/java/operator/src/main/java/com/instaclustr/cassandra/operator/controller/DataCenterDeletionController.java
@@ -9,6 +9,7 @@ import com.instaclustr.cassandra.operator.k8s.K8sLoggingSupport;
 import com.instaclustr.cassandra.operator.k8s.K8sResourceUtils;
 import com.instaclustr.cassandra.operator.k8s.OperatorLabels;
 import com.instaclustr.cassandra.operator.model.key.DataCenterKey;
+import com.instaclustr.k8s.K8sLabels;
 import com.instaclustr.slf4j.MDC;
 import io.kubernetes.client.ApiException;
 import io.kubernetes.client.apis.AppsV1beta2Api;
@@ -40,7 +41,7 @@ public class DataCenterDeletionController {
             final String labelSelector = Joiner.on(',').withKeyValueSeparator('=').join(
                     ImmutableMap.of(
                             OperatorLabels.DATACENTER, dataCenterKey.name,
-                            "app.kubernetes.io/managed-by", "com.instaclustr.cassandra-operator"
+                            K8sLabels.MANAGED_BY, OperatorLabels.OPERATOR_IDENTIFIER
                     )
             );
 

--- a/java/operator/src/main/java/com/instaclustr/cassandra/operator/k8s/OperatorLabels.java
+++ b/java/operator/src/main/java/com/instaclustr/cassandra/operator/k8s/OperatorLabels.java
@@ -3,5 +3,7 @@ package com.instaclustr.cassandra.operator.k8s;
 public final class OperatorLabels {
     public static final String DATACENTER = "cassandra-operator.instaclustr.com/datacenter";
 
+    public static final String OPERATOR_IDENTIFIER = "com.instaclustr.cassandra-operator";
+
     private OperatorLabels() {}
 }

--- a/java/operator/src/main/java/com/instaclustr/cassandra/operator/service/CassandraHealthCheckService.java
+++ b/java/operator/src/main/java/com/instaclustr/cassandra/operator/service/CassandraHealthCheckService.java
@@ -88,7 +88,7 @@ public class CassandraHealthCheckService extends AbstractScheduledService {
 
                             cassandraNodeOperationModes.put(podIp, mode);
 
-                            if (previousMode != null && !previousMode.equals(mode)) {
+                            if (previousMode == null || !previousMode.equals(mode)) {
                                 eventBus.post(new CassandraNodeOperationModeChangedEvent(pod, dataCenterKey, previousMode, mode));
                             }
 

--- a/java/operator/src/main/java/com/instaclustr/cassandra/operator/watch/ConfigMapWatchModule.java
+++ b/java/operator/src/main/java/com/instaclustr/cassandra/operator/watch/ConfigMapWatchModule.java
@@ -8,7 +8,10 @@ import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.Multibinder;
 import com.instaclustr.cassandra.operator.configuration.Namespace;
 import com.instaclustr.cassandra.operator.event.ConfigMapWatchEvent;
+import com.instaclustr.cassandra.operator.k8s.OperatorLabels;
 import com.instaclustr.cassandra.operator.model.key.ConfigMapKey;
+import com.instaclustr.k8s.K8sLabels;
+import com.instaclustr.k8s.LabelSelectors;
 import com.instaclustr.k8s.watch.ResourceCache;
 import com.instaclustr.k8s.watch.WatchService;
 import com.squareup.okhttp.Call;
@@ -61,7 +64,9 @@ public class ConfigMapWatchModule extends AbstractModule {
 
         @Override
         protected Call listResources(final String continueToken, final String resourceVersion, final boolean watch) throws ApiException {
-            return coreApi.listNamespacedConfigMapCall(namespace, null, null, continueToken, null, "operator=instaclustr-cassandra-operator", null, resourceVersion, null, watch, null, null);
+            final String labelSelector = LabelSelectors.equalitySelector(K8sLabels.MANAGED_BY, OperatorLabels.OPERATOR_IDENTIFIER);
+
+            return coreApi.listNamespacedConfigMapCall(namespace, null, null, continueToken, null, labelSelector, null, resourceVersion, null, watch, null, null);
         }
 
         @Override

--- a/java/operator/src/main/java/com/instaclustr/cassandra/operator/watch/StatefulSetWatchModule.java
+++ b/java/operator/src/main/java/com/instaclustr/cassandra/operator/watch/StatefulSetWatchModule.java
@@ -8,7 +8,10 @@ import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.Multibinder;
 import com.instaclustr.cassandra.operator.configuration.Namespace;
 import com.instaclustr.cassandra.operator.event.StatefulSetWatchEvent;
+import com.instaclustr.cassandra.operator.k8s.OperatorLabels;
 import com.instaclustr.cassandra.operator.model.key.StatefulSetKey;
+import com.instaclustr.k8s.K8sLabels;
+import com.instaclustr.k8s.LabelSelectors;
 import com.instaclustr.k8s.watch.ResourceCache;
 import com.instaclustr.k8s.watch.WatchService;
 import com.squareup.okhttp.Call;
@@ -61,7 +64,9 @@ public class StatefulSetWatchModule extends AbstractModule {
 
         @Override
         protected Call listResources(final String continueToken, final String resourceVersion, final boolean watch) throws ApiException {
-            return appsApi.listNamespacedStatefulSetCall(namespace, null, null, continueToken, null, "operator=instaclustr-cassandra-operator", null, resourceVersion, null, watch, null, null);
+            final String labelSelector = LabelSelectors.equalitySelector(K8sLabels.MANAGED_BY, OperatorLabels.OPERATOR_IDENTIFIER);
+
+            return appsApi.listNamespacedStatefulSetCall(namespace, null, null, continueToken, null, labelSelector, null, resourceVersion, null, watch, null, null);
         }
 
         @Override

--- a/java/operator/src/main/java/com/instaclustr/k8s/K8sLabels.java
+++ b/java/operator/src/main/java/com/instaclustr/k8s/K8sLabels.java
@@ -1,0 +1,7 @@
+package com.instaclustr.k8s;
+
+public final class K8sLabels {
+    public static final String MANAGED_BY = "app.kubernetes.io/managed-by";
+
+    private K8sLabels() {}
+}

--- a/java/operator/src/main/java/com/instaclustr/k8s/LabelSelectors.java
+++ b/java/operator/src/main/java/com/instaclustr/k8s/LabelSelectors.java
@@ -1,0 +1,20 @@
+package com.instaclustr.k8s;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+public final class LabelSelectors {
+
+    public static String equalitySelector(final String label, final String value) {
+        return equalitySelector(ImmutableMap.of(label, value));
+    }
+
+    public static String equalitySelector(final Map<String, String> labelsAndValues) {
+        return Joiner.on(',').withKeyValueSeparator('=').join(labelsAndValues);
+    }
+
+
+    private LabelSelectors() {}
+}


### PR DESCRIPTION
- Fixes incorrect label selector defined for WatchServices which prevented them from observing modification events.
- Simplifies triggering logic for reconciliation on StatefulSet changes.