### PR TITLE
Remove slash from leader ConfigMap name

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -77,7 +77,7 @@ func main() {
 	ctx := context.TODO()
 
 	// Become the leader before proceeding
-	err = leader.Become(ctx, "cassandra-operator/-lock")
+	err = leader.Become(ctx, "cassandra-operator-lock")
 	if err != nil {
 		log.Error(err, "")
 		os.Exit(1)


### PR DESCRIPTION
The slash causes startup errors. This looks like a typo to me.