### PR TITLE
Improve Go build process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.circleci
+vendor

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,13 @@ all: java docker
 .PHONY: java
 java:
 	cd java && mvn install
-	
+
+# Build cassandra-operator binary
+.PHONY: operator
+operator:
+	cd cmd/manager && go build
+
+# Build Docker images
 .PHONY: docker
 docker: java
 	$(MAKE) -C $@

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,13 @@ all: java docker
 java:
 	cd java && mvn install
 
+# Obtain operator version from Git
+git_revision = $(shell git describe --tags --always --dirty)
+
 # Build cassandra-operator binary
 .PHONY: operator
 operator:
-	cd cmd/manager && go build
+	cd cmd/manager && go build -ldflags "-X main.version=$(git_revision)"
 
 # Build Docker images
 .PHONY: docker

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -30,6 +30,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
+// Populated at build time.
+var version = "undefined"
+
 // Change below variables to serve metrics on different host or port.
 var (
 	metricsHost               = "0.0.0.0"
@@ -39,6 +42,7 @@ var (
 var log = logf.Log.WithName("cmd")
 
 func printVersion() {
+	log.Info(fmt.Sprintf("Version: %s", version))
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -18,7 +18,7 @@ spec:
           # Replace this with the built image name
           image: REPLACE_IMAGE
           command:
-          - cassandra-operator
+          - ./cassandra-operator
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/docker/cassandra-operator/Dockerfile
+++ b/docker/cassandra-operator/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang AS builder
 
+ARG version
+
 # Create a user so that operator can run as non-root
 RUN useradd -u 999 cassandra-operator
 
@@ -8,7 +10,9 @@ WORKDIR /code
 
 # Build binary
 RUN cd cmd/manager \
-    && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-w' -o /tmp/cassandra-operator
+    && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+        -ldflags "-w -X main.version=${version}" \
+        -o /tmp/cassandra-operator
 
 # Build final image
 FROM scratch

--- a/docker/cassandra-operator/Dockerfile
+++ b/docker/cassandra-operator/Dockerfile
@@ -1,9 +1,19 @@
-FROM debian:stretch
+FROM golang AS builder
 
-RUN mkdir -p /opt/{bin,lib/cassandra-operator}
+# Create a user so that operator can run as non-root
+RUN useradd -u 999 cassandra-operator
 
-COPY cassandra-operator.sh /opt/bin/cassandra-operator
+COPY . /code
+WORKDIR /code
 
-ENV PATH = $PATH:/opt/bin
+# Build binary
+RUN cd cmd/manager \
+    && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-w' -o /tmp/cassandra-operator
 
-CMD cassandra-operator
+# Build final image
+FROM scratch
+
+COPY --from=builder /tmp/cassandra-operator .
+COPY --from=builder /etc/passwd /etc/passwd
+USER 999
+CMD ["./cassandra-operator"]

--- a/docker/cassandra-operator/Makefile
+++ b/docker/cassandra-operator/Makefile
@@ -1,10 +1,13 @@
 
 # Figure out the path to the root of the repository
 rootdir = $(shell git rev-parse --show-toplevel)
+# Obtain operator version from Git
+git_revision = $(shell git describe --tags --always --dirty)
 
 .PHONY: cassandra-operator
 cassandra-operator:
 	cd $(rootdir) && docker build \
+		--build-arg version=$(git_revision) \
 		-t $(DOCKER_REGISTRY)cassandra-operator \
 		-f docker/cassandra-operator/Dockerfile \
 		.

--- a/docker/cassandra-operator/Makefile
+++ b/docker/cassandra-operator/Makefile
@@ -1,8 +1,12 @@
 
+# Figure out the path to the root of the repository
+rootdir = $(shell git rev-parse --show-toplevel)
+
 .PHONY: cassandra-operator
 cassandra-operator:
-	docker build \
+	cd $(rootdir) && docker build \
 		-t $(DOCKER_REGISTRY)cassandra-operator \
+		-f docker/cassandra-operator/Dockerfile \
 		.
 
 .PHONY: clean

--- a/docker/cassandra-operator/cassandra-operator.sh
+++ b/docker/cassandra-operator/cassandra-operator.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-echo "hello world"


### PR DESCRIPTION
This PR improves the build process for the Go version of the operator, both for plain binaries and for Docker images.

Changes:

- Replace dummy Dockerfile with a real one.
- Add a `.dockerignore` file to exclude irrelevant files from Docker builds.
- Add Make targets for building Go binaries.
- Bake operator version into the binary and print it during initialization.