### PR TITLE
Fix Docker image name handling

### DIFF
--- a/buildenv/build
+++ b/buildenv/build
@@ -9,6 +9,6 @@ cd `dirname "$BASH_SOURCE"`/..
 
 source ./buildenv/repo
 
-echo "Building ${REPO}:${TAG}"
+echo "Building ${REGISTRY}:${TAG}"
 
-docker build --tag "${REPO}:${TAG}" --tag "${REPO}:latest" --tag "$1" docker/${1} 1>/dev/null
+docker build --tag "${REGISTRY}:${TAG}" --tag "${REGISTRY}:latest" --tag "$1" docker/${1} 1>/dev/null

--- a/buildenv/build-all
+++ b/buildenv/build-all
@@ -3,7 +3,7 @@
 
 cd `dirname "$BASH_SOURCE"`/..
 
-export DOCKER_REPO="${REPO:-gcr.io/cassandra-operator}"
+export DOCKER_REGISTRY="${REGISTRY:-gcr.io/cassandra-operator/}"
 
 cd docker
 make

--- a/buildenv/build-cassandra
+++ b/buildenv/build-cassandra
@@ -11,6 +11,6 @@ source ./buildenv/repo
 
 echo "Building Cassandra versions in version list"
 while IFS="" read -r line || [[ -n "$line" ]]; do
-    echo "Building ${REPO}:${line}"
-    docker build --tag "${REPO}:${line}" --tag "${1}:${line}" --build-arg cassandra_version="${line}" docker/${1} 1>/dev/null
+    echo "Building ${REGISTRY}:${line}"
+    docker build --tag "${REGISTRY}:${line}" --tag "${1}:${line}" --build-arg cassandra_version="${line}" docker/${1} 1>/dev/null
 done < buildenv/CASSANDRA_VERSIONS

--- a/buildenv/release
+++ b/buildenv/release
@@ -6,7 +6,7 @@ set -o nounset
 set -o pipefail
 
 function defer {
-	if [[ $REPO == gcr.io/* ]]; then
+	if [[ $REGISTRY == gcr.io/* ]]; then
 		docker logout gcr.io
 	fi
 }
@@ -22,5 +22,5 @@ cd `dirname "$BASH_SOURCE"`/..
 
 source ./buildenv/repo
 
-docker push "${REPO}:${TAG}"  1>/dev/null
-docker push "${REPO}:latest"  1>/dev/null
+docker push "${REGISTRY}:${TAG}"  1>/dev/null
+docker push "${REGISTRY}:latest"  1>/dev/null

--- a/buildenv/release-all
+++ b/buildenv/release-all
@@ -7,7 +7,7 @@ set -o pipefail
 cd `dirname "$BASH_SOURCE"`/..
 
 function defer {
-	if [[ $REPO == gcr.io/* ]]; then
+	if [[ $REGISTRY == gcr.io/* ]]; then
 		docker logout gcr.io
 		export DONT_LOGIN="false"
 	fi
@@ -16,17 +16,17 @@ function defer {
 trap defer EXIT
 
 # We source this a bunch of times just to make stuff work. TODO: this needs a clean up
-REPO="${REPO:-gcr.io/cassandra-operator}"
+REGISTRY="${REGISTRY:-gcr.io/cassandra-operator}"
 
 
-if [[ $REPO == gcr.io/* ]]; then
+if [[ $REGISTRY == gcr.io/* ]]; then
 	gcloud docker -a
 fi
 
 export DONT_LOGIN="true"
 
-docker push "${REPO}/base-openjre:latest"
-docker push "${REPO}/cassandra-operator:latest"
-docker push "${REPO}/cassandra-sidecar:latest"
-docker push "${REPO}/cassandra:latest"
-docker push "${REPO}/cassandra:3.11.3"
+docker push "${REGISTRY}/base-openjre:latest"
+docker push "${REGISTRY}/cassandra-operator:latest"
+docker push "${REGISTRY}/cassandra-sidecar:latest"
+docker push "${REGISTRY}/cassandra:latest"
+docker push "${REGISTRY}/cassandra:3.11.3"

--- a/buildenv/release-cassandra
+++ b/buildenv/release-cassandra
@@ -24,10 +24,10 @@ source ./buildenv/repo
 
 echo "Pushing Cassandra versions in version list"
 while IFS="" read -r line || [[ -n "$line" ]]; do
-    echo "Pushing ${REPO}:${line}"
-    docker push "${REPO}:${line}"  1>/dev/null
+    echo "Pushing ${REGISTRY}:${line}"
+    docker push "${REGISTRY}:${line}"  1>/dev/null
 done < buildenv/CASSANDRA_VERSIONS
 
 
-#docker push "${REPO}:${TAG}"  1>/dev/null
-#docker push "${REPO}:latest"  1>/dev/null
+#docker push "${REGISTRY}:${TAG}"  1>/dev/null
+#docker push "${REGISTRY}:latest"  1>/dev/null

--- a/buildenv/repo
+++ b/buildenv/repo
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 
-# you can over ride REPO and TAG if needed
+# you can override REGISTRY and TAG if needed
 
-REPO="${REPO:-gcr.io/cassandra-operator}"
+REGISTRY="${REGISTRY:-gcr.io/cassandra-operator}"
 CIRCLE_TAG="${CIRCLE_TAG:-}"
 NO_DEV="${NO_DEV:-}"
 CIRCLE_BRANCH="${CIRCLE_BRANCH:-}"
-export REPO="$REPO/${1}"
+export REGISTRY="$REGISTRY/${1}"
 
 if [[ "${CIRCLE_TAG}" == "" ]] && [[ "${CIRCLE_BRANCH}" != master ]] && [[ "${NO_DEV}" != "true" ]]; then
-	export REPO="${REPO}-dev"
+	export REGISTRY="${REGISTRY}-dev"
 fi
 
 SHA1=`git rev-parse --short HEAD`

--- a/doc/developers.md
+++ b/doc/developers.md
@@ -35,4 +35,4 @@ This will by default build an images for the projects gcr.io development image r
 The default tag is the git short hash.
 e.g. `gcr.io/cassandra-operator/cassandra-operator-dev:0cf96c3` 
 
-This behavior can be overrode by defining `NO_DEV`, `REPO` and `TAG` environment variables. 
+This behavior can be overridden by defining `NO_DEV`, `REGISTRY` and `TAG` environment variables. 

--- a/docker/base-openjre/Makefile
+++ b/docker/base-openjre/Makefile
@@ -1,12 +1,12 @@
 OPENJRE_VERSION := "8u222-b10-1~deb9u1"
 OPENJRE_IMAGE_TAG := stretch-$(subst ~,-,$(OPENJRE_VERSION))
-OPENJRE_IMAGE := $(DOCKER_REPO)/base-openjre:$(OPENJRE_IMAGE_TAG)
+OPENJRE_IMAGE := $(DOCKER_REGISTRY)base-openjre:$(OPENJRE_IMAGE_TAG)
 
 .PHONY: base-openjre
 base-openjre:
 	docker build \
 		--build-arg openjre_version=$(OPENJRE_VERSION) \
-		-t $(DOCKER_REPO)/base-openjre \
+		-t $(DOCKER_REGISTRY)base-openjre \
 		-t $(OPENJRE_IMAGE) \
 		.
 

--- a/docker/cassandra-operator/Makefile
+++ b/docker/cassandra-operator/Makefile
@@ -2,7 +2,7 @@
 .PHONY: cassandra-operator
 cassandra-operator:
 	docker build \
-		-t $(DOCKER_REPO)/cassandra-operator \
+		-t $(DOCKER_REGISTRY)cassandra-operator \
 		.
 
 .PHONY: clean

--- a/docker/cassandra-sidecar/Makefile
+++ b/docker/cassandra-sidecar/Makefile
@@ -16,8 +16,8 @@ cassandra-sidecar: $(CASSANDRA_SIDECAR_JAR)
 	docker build \
 		--build-arg cassandra_sidecar_jar=$(CASSANDRA_SIDECAR_JAR) \
 		--build-arg openjre_image="$(OPENJRE_IMAGE)" \
-		-t $(DOCKER_REPO)/cassandra-sidecar \
-		-t $(DOCKER_REPO)/cassandra-sidecar:$(CASSANDRA_SIDECAR_VERSION) \
+		-t $(DOCKER_REGISTRY)cassandra-sidecar \
+		-t $(DOCKER_REGISTRY)cassandra-sidecar:$(CASSANDRA_SIDECAR_VERSION) \
 		.
 
 .PHONY: clean

--- a/docker/cassandra/Makefile
+++ b/docker/cassandra/Makefile
@@ -19,8 +19,8 @@ cassandra: $(CASSANDRA_K8S_ADDONS_JAR)
 		--build-arg cassandra_version=$(CASSANDRA_VERSION) \
 		--build-arg cassandra_k8s_addons_jar=$(CASSANDRA_K8S_ADDONS_JAR) \
 		--build-arg openjre_image="$(OPENJRE_IMAGE)" \
-		-t $(DOCKER_REPO)cassandra \
-		-t $(DOCKER_REPO)cassandra:$(CASSANDRA_VERSION) \
+		-t $(DOCKER_REGISTRY)cassandra \
+		-t $(DOCKER_REGISTRY)cassandra:$(CASSANDRA_VERSION) \
 		.
 
 .PHONY: clean


### PR DESCRIPTION
The current state generates tags such as `registry/repocassandra` instead of `registry/repo/cassandra`.
I'm assuming there should be slashes here from looking at the other Makefiles, for example [this one](https://github.com/instaclustr/cassandra-operator/blob/cfb76a760d0b6f1c5dcc272c758adb18b5109254/docker/cassandra-sidecar/Makefile#L19-L20).