### PR TITLE
Make sidecar respond to signals

### DIFF
--- a/docker/cassandra-sidecar/Dockerfile
+++ b/docker/cassandra-sidecar/Dockerfile
@@ -12,5 +12,5 @@ COPY cassandra-sidecar.sh /opt/bin/cassandra-sidecar
 
 ENV PATH = $PATH:/opt/bin
 
-CMD cassandra-sidecar
+CMD ["cassandra-sidecar"]
 


### PR DESCRIPTION
Fixes https://github.com/instaclustr/cassandra-operator/issues/212.

Using a [shell-form entrypoint](https://docs.docker.com/engine/reference/builder/#shell-form-entrypoint-example) causes PID 1 to be a shell which prevents signals from reaching the application. The result is slow termination of Cassandra pods.