### PR TITLE
Run Cassandra and sidecar as non-root

### DIFF
--- a/docker/cassandra-sidecar/Dockerfile
+++ b/docker/cassandra-sidecar/Dockerfile
@@ -4,6 +4,10 @@ FROM ${openjre_image}
 
 ARG cassandra_sidecar_jar
 
+# Create 'cassandra' user and group
+RUN groupadd -g 999 cassandra && \
+    useradd -r -u 999 -g cassandra cassandra
+
 RUN mkdir -p /opt/{bin,lib/cassandra-sidecar}
 
 COPY ${cassandra_sidecar_jar} /opt/lib/cassandra-sidecar/
@@ -12,5 +16,9 @@ COPY cassandra-sidecar.sh /opt/bin/cassandra-sidecar
 
 ENV PATH = $PATH:/opt/bin
 
-CMD ["cassandra-sidecar"]
+# Run as user 'cassandra'
+# A numeric UID is used for PSP support:
+# https://kubernetes.io/docs/concepts/policy/pod-security-policy/#users-and-groups
+USER 999
 
+CMD ["cassandra-sidecar"]

--- a/docker/cassandra/Dockerfile
+++ b/docker/cassandra/Dockerfile
@@ -19,6 +19,7 @@ COPY cql-readiness-probe /usr/bin/cql-readiness-probe
 COPY ${cassandra_k8s_addons_jar} /usr/share/cassandra/lib
 
 ADD default-config /etc/cassandra
+RUN chown -R cassandra:cassandra /etc/cassandra
 
 VOLUME /var/lib/cassandra
 VOLUME /etc/cassandra
@@ -29,5 +30,11 @@ VOLUME /etc/cassandra
 # 9042: CQL
 # 9160: thrift service
 EXPOSE 7000 7001 7199 9042 9160
+
+# Run as user 'cassandra'
+# A numeric UID is used for PSP support:
+# https://kubernetes.io/docs/concepts/policy/pod-security-policy/#users-and-groups
+# The user is created in ./install-cassandra
+USER 999
 
 ENTRYPOINT ["/usr/bin/entry-point"]

--- a/docker/cassandra/default-config/cassandra-env.sh.d/002-cassandra-limits.sh
+++ b/docker/cassandra/default-config/cassandra-env.sh.d/002-cassandra-limits.sh
@@ -1,1 +1,0 @@
-ulimit -l unlimited

--- a/docker/cassandra/install-cassandra
+++ b/docker/cassandra/install-cassandra
@@ -2,7 +2,9 @@
 
 cassandra_version=$1
 
-adduser --disabled-password --gid 0 --gecos "Cassandra" cassandra
+# create 'cassandra' user and group
+groupadd -g 999 cassandra
+useradd -r -u 999 -g cassandra cassandra
 
 pkg_dir=$(mktemp -d) && chmod 755 "${pkg_dir}"
 arch="all"


### PR DESCRIPTION
This PR makes C* and the sidecar run as a non-root user. Rationale:

- Running containers as root is less secure than non-root.
- Some clusters employ PSPs which prevent running containers as root. This change makes it possible to use the operator even on clusters with strict PSPs.
- As far as I can tell, root isn't really necessary for C* nor for the sidecar.