### PR TITLE
Version object populated from JarManifestVersionProvider and logged in CLI commands too

### DIFF
--- a/java/backup-restore/src/main/java/com/instaclustr/cassandra/backup/cli/BackupApplication.java
+++ b/java/backup-restore/src/main/java/com/instaclustr/cassandra/backup/cli/BackupApplication.java
@@ -2,34 +2,40 @@ package com.instaclustr.cassandra.backup.cli;
 
 import static com.instaclustr.cassandra.backup.cli.BackupRestoreCLI.init;
 import static com.instaclustr.picocli.CLIApplication.execute;
+import static com.instaclustr.picocli.JarManifestVersionProvider.logCommandVersionInformation;
 import static org.awaitility.Awaitility.await;
 
 import com.google.inject.Inject;
-import com.instaclustr.cassandra.backup.cli.BackupRestoreCLI.CLIJarManifestVersionProvider;
 import com.instaclustr.cassandra.backup.impl.backup.BackupOperationRequest;
 import com.instaclustr.picocli.CassandraJMXSpec;
 import com.instaclustr.sidecar.operations.Operation;
 import com.instaclustr.sidecar.operations.OperationsService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Spec;
 
-@CommandLine.Command(name = "backup",
-        mixinStandardHelpOptions = true,
-        description = "Take a snapshot of this nodes Cassandra data and upload it to remote storage. " +
-                "Defaults to a snapshot of all keyspaces and their column families, " +
-                "but may be restricted to specific keyspaces or a single column-family.",
-        sortOptions = false,
-        versionProvider = CLIJarManifestVersionProvider.class
+@Command(name = "backup",
+         mixinStandardHelpOptions = true,
+         description = "Take a snapshot of this nodes Cassandra data and upload it to remote storage. " +
+                 "Defaults to a snapshot of all keyspaces and their column families, " +
+                 "but may be restricted to specific keyspaces or a single column-family.",
+         sortOptions = false,
+         versionProvider = BackupRestoreCLI.class
 )
 public class BackupApplication implements Runnable {
 
     private static final Logger logger = LoggerFactory.getLogger(BackupApplication.class);
 
-    @CommandLine.Mixin
+    @Spec
+    private CommandSpec spec;
+
+    @Mixin
     private CassandraJMXSpec jmxSpec;
 
-    @CommandLine.Mixin
+    @Mixin
     private BackupOperationRequest request;
 
     @Inject
@@ -41,6 +47,8 @@ public class BackupApplication implements Runnable {
 
     @Override
     public void run() {
+        logCommandVersionInformation(spec);
+
         if (request.offlineSnapshot) {
             init(this, null, request, logger);
         } else {

--- a/java/backup-restore/src/main/java/com/instaclustr/cassandra/backup/cli/BackupRestoreCLI.java
+++ b/java/backup-restore/src/main/java/com/instaclustr/cassandra/backup/cli/BackupRestoreCLI.java
@@ -1,7 +1,5 @@
 package com.instaclustr.cassandra.backup.cli;
 
-import static com.instaclustr.picocli.CLIApplication.execute;
-
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.ValidationException;
@@ -17,8 +15,8 @@ import com.google.inject.Module;
 import com.google.inject.Stage;
 import com.instaclustr.cassandra.backup.guice.BackupRestoreModule;
 import com.instaclustr.guice.GuiceInjectorHolder;
+import com.instaclustr.picocli.CLIApplication;
 import com.instaclustr.picocli.CassandraJMXSpec;
-import com.instaclustr.picocli.JarManifestVersionProvider;
 import com.instaclustr.sidecar.operations.OperationRequest;
 import com.instaclustr.sidecar.operations.OperationsModule;
 import com.instaclustr.threading.ExecutorsModule;
@@ -28,27 +26,22 @@ import jmx.org.apache.cassandra.guice.CassandraModule;
 import jmx.org.apache.cassandra.service.StorageServiceMBean;
 import org.slf4j.Logger;
 import picocli.CommandLine;
+import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
 import picocli.CommandLine.Spec;
 
-@CommandLine.Command(
-        subcommands = {
-                BackupApplication.class,
-                RestoreApplication.class,
-                CommitLogBackupApplication.class,
-                CommitLogRestoreApplication.class
-        },
-        synopsisSubcommandLabel = "COMMAND",
-        versionProvider = BackupRestoreCLI.CLIJarManifestVersionProvider.class
+@Command(subcommands = {BackupApplication.class, RestoreApplication.class, CommitLogBackupApplication.class, CommitLogRestoreApplication.class},
+         synopsisSubcommandLabel = "COMMAND",
+         versionProvider = BackupRestoreCLI.class
 )
-public class BackupRestoreCLI implements Runnable {
+public class BackupRestoreCLI extends CLIApplication implements Runnable {
 
-    @CommandLine.Option(
-            names = {"-V", "--version"},
+    @Option(names = {"-V", "--version"},
             versionHelp = true,
             description = "print version information and exit"
     )
-    boolean versionRequested;
+    private boolean version;
 
     @Spec
     private CommandSpec spec;
@@ -98,9 +91,9 @@ public class BackupRestoreCLI implements Runnable {
         injector.injectMembers(command);
 
         final Validator validator = Validation.byDefaultProvider()
-                .configure()
-                .constraintValidatorFactory(new GuiceInjectingConstraintValidatorFactory()).buildValidatorFactory()
-                .getValidator();
+                                              .configure()
+                                              .constraintValidatorFactory(new GuiceInjectingConstraintValidatorFactory()).buildValidatorFactory()
+                                              .getValidator();
 
         final Set<ConstraintViolation<OperationRequest>> violations = validator.validate(operationRequest);
 
@@ -110,9 +103,8 @@ public class BackupRestoreCLI implements Runnable {
         }
     }
 
-    public static class CLIJarManifestVersionProvider extends JarManifestVersionProvider {
-        protected CLIJarManifestVersionProvider() {
-            super("backup-restore");
-        }
+    @Override
+    public String getImplementationTitle() {
+        return "backup-restore";
     }
 }

--- a/java/backup-restore/src/main/java/com/instaclustr/cassandra/backup/cli/CommitLogBackupApplication.java
+++ b/java/backup-restore/src/main/java/com/instaclustr/cassandra/backup/cli/CommitLogBackupApplication.java
@@ -2,28 +2,34 @@ package com.instaclustr.cassandra.backup.cli;
 
 import static com.instaclustr.cassandra.backup.cli.BackupRestoreCLI.init;
 import static com.instaclustr.picocli.CLIApplication.execute;
+import static com.instaclustr.picocli.JarManifestVersionProvider.logCommandVersionInformation;
 import static org.awaitility.Awaitility.await;
 
 import com.google.inject.Inject;
-import com.instaclustr.cassandra.backup.cli.BackupRestoreCLI.CLIJarManifestVersionProvider;
 import com.instaclustr.cassandra.backup.impl.backup.BackupCommitLogsOperationRequest;
 import com.instaclustr.sidecar.operations.Operation;
 import com.instaclustr.sidecar.operations.OperationsService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Spec;
 
-@CommandLine.Command(name = "commitlog-backup",
-        mixinStandardHelpOptions = true,
-        description = "Upload archived commit logs to remote storage.",
-        sortOptions = false,
-        versionProvider = CLIJarManifestVersionProvider.class
+@Command(name = "commitlog-backup",
+         mixinStandardHelpOptions = true,
+         description = "Upload archived commit logs to remote storage.",
+         sortOptions = false,
+         versionProvider = BackupRestoreCLI.class
 )
 public class CommitLogBackupApplication implements Runnable {
 
     private static final Logger logger = LoggerFactory.getLogger(CommitLogBackupApplication.class);
 
-    @CommandLine.Mixin
+    @Spec
+    private CommandSpec spec;
+
+    @Mixin
     private BackupCommitLogsOperationRequest request;
 
     @Inject
@@ -35,6 +41,8 @@ public class CommitLogBackupApplication implements Runnable {
 
     @Override
     public void run() {
+        logCommandVersionInformation(spec);
+
         init(this, null, request, logger);
 
         final Operation operation = operationsService.submitOperationRequest(request);

--- a/java/backup-restore/src/main/java/com/instaclustr/cassandra/backup/cli/CommitLogRestoreApplication.java
+++ b/java/backup-restore/src/main/java/com/instaclustr/cassandra/backup/cli/CommitLogRestoreApplication.java
@@ -2,6 +2,7 @@ package com.instaclustr.cassandra.backup.cli;
 
 import static com.instaclustr.cassandra.backup.cli.BackupRestoreCLI.init;
 import static com.instaclustr.picocli.CLIApplication.execute;
+import static com.instaclustr.picocli.JarManifestVersionProvider.logCommandVersionInformation;
 import static org.awaitility.Awaitility.await;
 
 import com.google.inject.Inject;
@@ -10,19 +11,25 @@ import com.instaclustr.sidecar.operations.Operation;
 import com.instaclustr.sidecar.operations.OperationsService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Spec;
 
-@CommandLine.Command(name = "commitlog-restore",
-        mixinStandardHelpOptions = true,
-        description = "Restores archived commit logs to node.",
-        sortOptions = false,
-        versionProvider = BackupRestoreCLI.CLIJarManifestVersionProvider.class
+@Command(name = "commitlog-restore",
+         mixinStandardHelpOptions = true,
+         description = "Restores archived commit logs to node.",
+         sortOptions = false,
+         versionProvider = BackupRestoreCLI.class
 )
 public class CommitLogRestoreApplication implements Runnable {
 
     private static final Logger logger = LoggerFactory.getLogger(CommitLogRestoreApplication.class);
 
-    @CommandLine.Mixin
+    @Spec
+    private CommandSpec spec;
+
+    @Mixin
     private RestoreCommitLogsOperationRequest request;
 
     @Inject
@@ -34,6 +41,8 @@ public class CommitLogRestoreApplication implements Runnable {
 
     @Override
     public void run() {
+        logCommandVersionInformation(spec);
+
         init(this, null, request, logger);
 
         final Operation operation = operationsService.submitOperationRequest(request);

--- a/java/backup-restore/src/main/java/com/instaclustr/cassandra/backup/cli/RestoreApplication.java
+++ b/java/backup-restore/src/main/java/com/instaclustr/cassandra/backup/cli/RestoreApplication.java
@@ -2,28 +2,34 @@ package com.instaclustr.cassandra.backup.cli;
 
 import static com.instaclustr.cassandra.backup.cli.BackupRestoreCLI.init;
 import static com.instaclustr.picocli.CLIApplication.execute;
+import static com.instaclustr.picocli.JarManifestVersionProvider.logCommandVersionInformation;
 import static org.awaitility.Awaitility.await;
 
 import com.google.inject.Inject;
-import com.instaclustr.cassandra.backup.cli.BackupRestoreCLI.CLIJarManifestVersionProvider;
 import com.instaclustr.cassandra.backup.impl.restore.RestoreOperationRequest;
 import com.instaclustr.sidecar.operations.Operation;
 import com.instaclustr.sidecar.operations.OperationsService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Spec;
 
-@CommandLine.Command(name = "restore",
-        mixinStandardHelpOptions = true,
-        description = "Restore the Cassandra data on this node to a specified point-in-time.",
-        sortOptions = false,
-        versionProvider = CLIJarManifestVersionProvider.class
+@Command(name = "restore",
+         mixinStandardHelpOptions = true,
+         description = "Restore the Cassandra data on this node to a specified point-in-time.",
+         sortOptions = false,
+         versionProvider = BackupRestoreCLI.class
 )
 public class RestoreApplication implements Runnable {
 
     private static final Logger logger = LoggerFactory.getLogger(RestoreApplication.class);
 
-    @CommandLine.Mixin
+    @Spec
+    private CommandSpec spec;
+
+    @Mixin
     private RestoreOperationRequest request;
 
     @Inject
@@ -35,6 +41,8 @@ public class RestoreApplication implements Runnable {
 
     @Override
     public void run() {
+        logCommandVersionInformation(spec);
+
         init(this, null, request, logger);
 
         final Operation operation = operationsService.submitOperationRequest(request);

--- a/java/common/src/main/java/com/instaclustr/picocli/CLIApplication.java
+++ b/java/common/src/main/java/com/instaclustr/picocli/CLIApplication.java
@@ -6,7 +6,7 @@ import java.util.concurrent.Callable;
 
 import picocli.CommandLine;
 
-public class CLIApplication {
+public abstract class CLIApplication extends JarManifestVersionProvider {
 
     public static int execute(final Runnable runnable, String... args) {
         return execute(new CommandLine(runnable), args);

--- a/java/common/src/main/java/com/instaclustr/picocli/JarManifestVersionProvider.java
+++ b/java/common/src/main/java/com/instaclustr/picocli/JarManifestVersionProvider.java
@@ -11,14 +11,9 @@ import com.google.common.base.Joiner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
+import picocli.CommandLine.IVersionProvider;
 
-public abstract class JarManifestVersionProvider implements CommandLine.IVersionProvider {
-    private static final Logger logger = LoggerFactory.getLogger(JarManifestVersionProvider.class);
-    private final String implementationTitle;
-
-    protected JarManifestVersionProvider(final String implementationTitle) {
-        this.implementationTitle = implementationTitle;
-    }
+public abstract class JarManifestVersionProvider implements IVersionProvider {
 
     @Override
     public String[] getVersion() throws IOException {
@@ -44,15 +39,17 @@ public abstract class JarManifestVersionProvider implements CommandLine.IVersion
         }
 
         return new String[]{
-                String.format("%s %s", implementationTitle, implementationVersion.orElse("development build")),
+                String.format("%s %s", getImplementationTitle(), implementationVersion.orElse("development build")),
                 String.format("Build time: %s", buildTime.orElse("unknown")),
                 String.format("Git commit: %s", gitCommit.orElse("unknown")),
         };
     }
 
     private boolean isApplicableManifest(Attributes attributes) {
-        return implementationTitle.equals(attributes.getValue(Attributes.Name.IMPLEMENTATION_TITLE));
+        return getImplementationTitle().equals(attributes.getValue(Attributes.Name.IMPLEMENTATION_TITLE));
     }
+
+    public abstract String getImplementationTitle();
 
     public static void logCommandVersionInformation(final CommandLine.Model.CommandSpec commandSpec) {
         final Logger logger = LoggerFactory.getLogger(commandSpec.userObject().getClass());

--- a/java/common/src/main/java/com/instaclustr/version/Version.java
+++ b/java/common/src/main/java/com/instaclustr/version/Version.java
@@ -4,23 +4,51 @@ import com.google.common.base.MoreObjects;
 
 public class Version {
     public final String version;
+    public final String buildTime;
+    public final String gitCommit;
 
-    public Version(final String[] version) {
-        if (version == null) {
-            this.version = "unknown";
-        } else {
-            this.version = String.join(", ", version);
-        }
+    public Version(final String version, final String buildTime, final String gitCommit) {
+        this.version = version;
+        this.buildTime = buildTime;
+        this.gitCommit = gitCommit;
     }
 
-    public Version(final String version) {
-        this(new String[]{version});
+    public static Version parse(final String[] versionArray) {
+        String version = "unknown";
+        String buildTime = "unknown";
+        String gitCommit = "unknown";
+
+        if (versionArray != null) {
+            if (versionArray.length > 0) {
+                version = versionArray[0];
+            }
+
+            if (versionArray.length > 1 && versionArray[1] != null) {
+                buildTime = parseEntry(versionArray[1]);
+            }
+
+            if (versionArray.length > 2 && versionArray[2] != null) {
+                gitCommit = parseEntry(versionArray[2]);
+            }
+        }
+
+        return new Version(version, buildTime, gitCommit);
+    }
+
+    private static String parseEntry(final String entry) {
+        if (entry.contains(":")) {
+            return entry.substring(entry.indexOf(":") + 1).trim();
+        } else {
+            return entry;
+        }
     }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                .add("version", version)
-                .toString();
+                          .add("version", version)
+                          .add("buildTime", buildTime)
+                          .add("gitCommit", gitCommit)
+                          .toString();
     }
 }

--- a/java/common/src/main/java/com/instaclustr/version/VersionModule.java
+++ b/java/common/src/main/java/com/instaclustr/version/VersionModule.java
@@ -6,7 +6,7 @@ public class VersionModule extends AbstractModule {
     private final Version version;
 
     public VersionModule(final String[] version) {
-        this(new Version(version));
+        this(Version.parse(version));
     }
 
     public VersionModule(final Version version) {

--- a/java/common/src/test/java/com/instaclustr/version/VersionTest.java
+++ b/java/common/src/test/java/com/instaclustr/version/VersionTest.java
@@ -6,9 +6,8 @@ public class VersionTest {
 
     @Test
     public void testVersion() {
-        final Version version = new Version("1.2.3");
-        final Version version2 = new Version(new String[]{"1", "2", "3"});
-        final Version version3 = new Version((String) null);
-        final Version version4 = new Version((String[]) null);
+        final Version version = Version.parse(new String[]{});
+        final Version version2 = Version.parse(new String[]{"name", "buildTime", "gitCommit"});
+        final Version version3 = Version.parse(null);
     }
 }

--- a/java/sidecar/src/main/java/com/instaclustr/cassandra/sidecar/Sidecar.java
+++ b/java/sidecar/src/main/java/com/instaclustr/cassandra/sidecar/Sidecar.java
@@ -1,7 +1,5 @@
 package com.instaclustr.cassandra.sidecar;
 
-import static com.instaclustr.picocli.JarManifestVersionProvider.logCommandVersionInformation;
-
 import java.util.concurrent.Callable;
 
 import com.google.inject.Guice;
@@ -17,14 +15,13 @@ import com.instaclustr.cassandra.sidecar.operations.decommission.Decommissioning
 import com.instaclustr.cassandra.sidecar.operations.rebuild.RebuildModule;
 import com.instaclustr.cassandra.sidecar.operations.scrub.ScrubModule;
 import com.instaclustr.cassandra.sidecar.operations.upgradesstables.UpgradeSSTablesModule;
-import com.instaclustr.cassandra.sidecar.picocli.SidecarJarManifestVersionProvider;
 import com.instaclustr.guice.Application;
 import com.instaclustr.guice.ServiceManagerModule;
 import com.instaclustr.picocli.CLIApplication;
 import com.instaclustr.picocli.CassandraJMXSpec;
-import com.instaclustr.sidecar.picocli.SidecarSpec;
 import com.instaclustr.sidecar.http.JerseyHttpServerModule;
 import com.instaclustr.sidecar.operations.OperationsModule;
+import com.instaclustr.sidecar.picocli.SidecarSpec;
 import com.instaclustr.threading.ExecutorsModule;
 import com.instaclustr.version.VersionModule;
 import jmx.org.apache.cassandra.JMXConnectionInfo;
@@ -36,10 +33,10 @@ import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Spec;
 
 @Command(name = "cassandra-sidecar",
-        mixinStandardHelpOptions = true,
-        description = "Sidecar management application for Apache Cassandra running on Kubernetes.",
-        versionProvider = SidecarJarManifestVersionProvider.class,
-        sortOptions = false
+         mixinStandardHelpOptions = true,
+         description = "Sidecar management application for Apache Cassandra running on Kubernetes.",
+         versionProvider = Sidecar.class,
+         sortOptions = false
 )
 public final class Sidecar extends CLIApplication implements Callable<Void> {
 
@@ -67,7 +64,7 @@ public final class Sidecar extends CLIApplication implements Callable<Void> {
         final Injector injector = Guice.createInjector(
                 Stage.PRODUCTION, // production binds singletons as eager by default
 
-                new VersionModule(commandSpec.version()),
+                new VersionModule(getVersion()),
                 new ServiceManagerModule(),
 
                 new CassandraModule(new JMXConnectionInfo(jmxSpec.jmxPassword,
@@ -93,5 +90,10 @@ public final class Sidecar extends CLIApplication implements Callable<Void> {
         );
 
         return injector.getInstance(Application.class).call();
+    }
+
+    @Override
+    public String getImplementationTitle() {
+        return "cassandra-sidecar";
     }
 }

--- a/java/sidecar/src/main/java/com/instaclustr/cassandra/sidecar/picocli/SidecarJarManifestVersionProvider.java
+++ b/java/sidecar/src/main/java/com/instaclustr/cassandra/sidecar/picocli/SidecarJarManifestVersionProvider.java
@@ -1,9 +1,0 @@
-package com.instaclustr.cassandra.sidecar.picocli;
-
-import com.instaclustr.picocli.JarManifestVersionProvider;
-
-public class SidecarJarManifestVersionProvider extends JarManifestVersionProvider {
-    protected SidecarJarManifestVersionProvider() {
-        super("cassandra-sidecar");
-    }
-}


### PR DESCRIPTION
Version object is populated from JarManifestVersionProvider and sidecar endpoint returns build time, commit log and so on. This information is also logged on -v or --version switch on CLI and it is logged everytime such command is invoked at the very beginning.