### PR TITLE
Add a PSP for operator

### DIFF
--- a/deploy/psp.yaml
+++ b/deploy/psp.yaml
@@ -1,0 +1,40 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: cassandra-operator
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+  volumes:
+  - 'configMap'
+  - 'emptyDir'
+  - 'projected'
+  - 'secret'
+  - 'downwardAPI'
+  - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  readOnlyRootFilesystem: true

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -61,3 +61,11 @@ rules:
   - cassandrabackups
   verbs:
   - '*'
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - cassandra-operator


### PR DESCRIPTION
This PR adds a PodSecurityPolicy for the operator pod.

On some clusters some default PSP may prevent the operator from running. Shipping a PSP with the operator makes it easier for the cluster admin to figure out exactly what permissions are required by the operator, and provides a base for customizations.

## Testing

Deploy the operator to a k8s cluster as usual and apply `psp.yaml` using `kubectl` as well. Verify the PSP is indeed used by the operator by running the following:

```
kubect get pods --selector name=cassandra-operator -oyaml | grep psp
```

The output should be `kubernetes.io/psp: cassandra-operator`.