### PR TITLE
Improve reconcile loop

### DIFF
--- a/pkg/controller/cassandradatacenter/configmap.go
+++ b/pkg/controller/cassandradatacenter/configmap.go
@@ -49,7 +49,10 @@ func createOrUpdateOperatorConfigMap(rctx *reconciliationRequestContext, seedNod
 		return nil, err
 	}
 
-	logger.Info(fmt.Sprintf("ConfigMap %s.", opresult))
+	// Only log if something has changed
+	if opresult != controllerutil.OperationResultNone {
+		logger.Info(fmt.Sprintf("ConfigMap %s %s.", configMap.Name, opresult))
+	}
 
 	configVolume := &corev1.Volume{
 		Name:         "operator-config-volume",
@@ -85,7 +88,11 @@ func createOrUpdateCassandraRackConfig(rctx *reconciliationRequestContext, rack 
 		return nil, err
 	}
 
-	logger.Info(fmt.Sprintf("ConfigMap %s.", opresult))
+
+	// Only log if something has changed
+	if opresult != controllerutil.OperationResultNone {
+		logger.Info(fmt.Sprintf("ConfigMap %s %s.", configMap.Name, opresult))
+	}
 
 	configVolume := &corev1.Volume{
 		Name:         "operator-rack-config-volume-" + rack.Name,

--- a/pkg/controller/cassandradatacenter/services.go
+++ b/pkg/controller/cassandradatacenter/services.go
@@ -36,7 +36,10 @@ func createOrUpdateNodesService(rctx *reconciliationRequestContext) (*corev1.Ser
 		return nil, err
 	}
 
-	logger.Info(fmt.Sprintf("Service %s.", opresult))
+	// Only log if something has changed
+	if opresult != controllerutil.OperationResultNone {
+		logger.Info(fmt.Sprintf("Service %s %s.", nodesService.Name, opresult))
+	}
 
 	return nodesService, err
 }
@@ -69,7 +72,10 @@ func createOrUpdateSeedNodesService(rctx *reconciliationRequestContext) (*corev1
 		return nil, err
 	}
 
-	logger.Info(fmt.Sprintf("Service %s.", opresult))
+	// Only log if something has changed
+	if opresult != controllerutil.OperationResultNone {
+		logger.Info(fmt.Sprintf("Service %s %s.", seedNodesService.Name, opresult))
+	}
 
 	return seedNodesService, err
 }


### PR DESCRIPTION
The current reconcile loop is not going to work if the decommission or creating of the new nodes takes a long time. The events that the reconcile responds to will come in fast initially, and if the cluster is undergoing an operation, the operator will do nothing with those events.

This change fixes this issue by requesting a repeat of the handler call after 1 minute after detecting that the cluster is in a "non-ready state"; this way the handler will always be called until all the events are worked out on and the cluster is reconciled to the new requested state. This works for building, scaling up and scaling down scenarios.

Signed-off-by: Alex Lourie <djay.il@gmail.com>