### PR TITLE
Use Go module mirror

### DIFF
--- a/docker/cassandra-operator/Dockerfile
+++ b/docker/cassandra-operator/Dockerfile
@@ -2,6 +2,8 @@ FROM golang AS builder
 
 ARG version
 
+ENV GOPROXY=https://proxy.golang.org
+
 # Create a user so that operator can run as non-root
 RUN useradd -u 999 cassandra-operator
 


### PR DESCRIPTION
This greatly reduces the time it requires for the Go tool to download modules.

More info: https://blog.golang.org/module-mirror-launch