### PR TITLE
Fixes and improvements

### DIFF
--- a/pkg/common/cluster/utils.go
+++ b/pkg/common/cluster/utils.go
@@ -10,16 +10,14 @@ func BuildRacksDistribution(spec v1alpha1.CassandraDataCenterSpec) (racksDistrib
 	// If racks are not provided, we place everything in 1 Rack
 	if spec.Racks == nil {
 		spec.Racks = []v1alpha1.Rack{{Name: "rack1"}}
-	} else  {
+	} else {
 		// Sort racks alphabetically by name
 		sort.SliceStable(spec.Racks, func(i, j int) bool {
 			return spec.Racks[i].Name < spec.Racks[j].Name
 		})
 	}
 
-
-
-	// Now build the distribution
+	// otherwise, build the distribution
 	numRacks := int32(len(spec.Racks))
 	for i, rack := range spec.Racks {
 		replicas := spec.Nodes / numRacks

--- a/pkg/controller/cassandradatacenter/configmap.go
+++ b/pkg/controller/cassandradatacenter/configmap.go
@@ -37,7 +37,6 @@ func createOrUpdateOperatorConfigMap(rctx *reconciliationRequestContext, seedNod
 
 		addPrometheusSupport(rctx.cdc, addFileFn)
 
-
 		if err := controllerutil.SetControllerReference(rctx.cdc, configMap, rctx.scheme); err != nil {
 			return err
 		}
@@ -87,7 +86,6 @@ func createOrUpdateCassandraRackConfig(rctx *reconciliationRequestContext, rack 
 	if err != nil {
 		return nil, err
 	}
-
 
 	// Only log if something has changed
 	if opresult != controllerutil.OperationResultNone {

--- a/pkg/controller/cassandradatacenter/errors.go
+++ b/pkg/controller/cassandradatacenter/errors.go
@@ -3,5 +3,5 @@ package cassandradatacenter
 import "errors"
 
 var (
-	ErrorCDCNotReady = errors.New("skipping stateful set reconcile, some pods or cassandra nodes are not ready")
+	ErrorClusterNotReady = errors.New("skipping stateful set reconcile, some pods or cassandra nodes are not ready")
 )

--- a/pkg/controller/cassandradatacenter/helpers.go
+++ b/pkg/controller/cassandradatacenter/helpers.go
@@ -1,0 +1,86 @@
+package cassandradatacenter
+
+import (
+	"context"
+	"github.com/instaclustr/cassandra-operator/pkg/apis/cassandraoperator/v1alpha1"
+	"k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sort"
+	"strings"
+)
+
+func sortAscending(sets []v1.StatefulSet) (s []v1.StatefulSet) {
+	// Sort sets from lowest to highest numerically by the number of the nodes in the set
+	sort.SliceStable(sets, func(i, j int) bool {
+		return sets[i].Status.Replicas < sets[j].Status.Replicas
+	})
+	return sets
+}
+
+func sortDescending(sets []v1.StatefulSet) (s []v1.StatefulSet) {
+	// Sort sets from highest to lowest numerically by the number of the nodes in the set
+	sort.SliceStable(sets, func(i, j int) bool {
+		return sets[i].Status.Replicas > sets[j].Status.Replicas
+	})
+	return sets
+}
+
+func AllPodsInCDC(c client.Client, cdc *v1alpha1.CassandraDataCenter) ([]corev1.Pod, error) {
+	return getPods(c, cdc.Namespace, DataCenterLabels(cdc))
+}
+
+func AllPodsInRack(c client.Client, namespace string, rackLabels map[string]string) ([]corev1.Pod, error) {
+	return getPods(c, namespace, rackLabels)
+}
+
+func getPods(c client.Client, namespace string, l map[string]string) ([]corev1.Pod, error) {
+	podList := corev1.PodList{}
+	listOps := &client.ListOptions{
+		Namespace:     namespace,
+		LabelSelector: labels.SelectorFromSet(l),
+	}
+
+	if err := c.List(context.TODO(), listOps, &podList); err != nil {
+		return nil, err
+	}
+
+	pods := podList.Items
+
+	//sort.Slice(pods, func(i, j int) bool {
+	//	return pods[i].Labels["cassandra-operator.instaclustr.com/rack"] < pods[j].Labels["cassandra-operator.instaclustr.com/rack"]
+	//})
+
+	return pods, nil
+}
+
+func allPodsAreRunning(pods []corev1.Pod) (bool, []string) {
+	// return whether all pods are running and the list of pods that are not running
+	var notRunningPodNames []string
+	for _, pod := range pods {
+		if pod.Status.Phase != corev1.PodRunning {
+			notRunningPodNames = append(notRunningPodNames, pod.Name)
+		}
+	}
+	return len(notRunningPodNames) == 0, notRunningPodNames
+}
+
+func podsToString(pods []*corev1.Pod) string {
+	// return the list of pod names as a string
+	var podNames []string
+	for _, pod := range pods {
+		podNames = append(podNames, pod.Name)
+	}
+	return strings.Join(podNames, ",")
+}
+
+func rackExist(name string, sets []v1.StatefulSet) bool {
+	// check if a rack exists in the list of racks
+	for _, set := range sets {
+		if set.Labels[rackKey] == name {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/sidecar/client.go
+++ b/pkg/sidecar/client.go
@@ -37,16 +37,16 @@ type Client struct {
 }
 
 type ClientOptions struct {
-	Secure   bool
-	Port     int32
-	Timeout  time.Duration
+	Secure  bool
+	Port    int32
+	Timeout time.Duration
 }
 
 func NewSidecarClient(host string, options *ClientOptions) *Client {
 
 	if options == nil {
 		options = &ClientOptions{
-			Secure:   true,
+			Secure: true,
 		}
 	}
 

--- a/pkg/sidecar/client_test.go
+++ b/pkg/sidecar/client_test.go
@@ -170,7 +170,7 @@ func TestClient_BackupNode(t *testing.T) {
 
 	request := &BackupRequest{
 		StorageLocation: "s3://my-bucket/cassandra-dc/test-node-0",
-		SnapshotTag: "mySnapshot",
+		SnapshotTag:     "mySnapshot",
 	}
 
 	if operationID, err := client.StartOperation(request); err != nil {


### PR DESCRIPTION
Updates to reconcile loop:

* Refactor the checkClusterHealth to run before initiating the
reconcile.

This new step should considerably improve the workflow by checking the
cluster health before doing anything at all. If the cluster is not in an
ok state, the operator should create/update any additional resources and
should just wait until the cluster is "ok" again.

The additional benefit is that we don't need to check the health of the
cluster again during the specific StatefulSet reconcile call, which
significantly simplified the code.

* Refactor reconciliationContext to include all current stateful sets,
all pods and sidecar clients. Additionally it now includes the type of
the current scaling operation (up, down or none)

This allows building these resources once for any given reconciliation
cycle. They also become available immediately to lots of other functions
that already receive this context and make the code more readable.

* Small fixes and improvements.
* More comments explaining important areas.

Signed-off-by: Alex Lourie <djay.il@gmail.com>
Signed-off-by: Stefan Miklosovic <stefan.miklosovic@instaclustr.com>