### PR TITLE
Make kernel tweaks optional

### DIFF
--- a/deploy/crds/cassandraoperator_v1alpha1_cassandradatacenter_crd.yaml
+++ b/deploy/crds/cassandraoperator_v1alpha1_cassandradatacenter_crd.yaml
@@ -52,7 +52,7 @@ spec:
             nodes:
               format: int32
               type: integer
-            privilegedSupported:
+            optimizeKernelParams:
               type: boolean
             prometheusSupport:
               type: boolean

--- a/docker/cassandra/Dockerfile
+++ b/docker/cassandra/Dockerfile
@@ -10,6 +10,13 @@ COPY install-cassandra /tmp/install-cassandra
 RUN /tmp/install-cassandra ${cassandra_version}
 
 COPY entry-point /usr/bin/entry-point
+COPY wrapper /usr/bin/wrapper
+
+# Allow entrypoint script to modify ulimit by creating a "patched" Bash executable
+# which is allowed to use the required capabilities
+RUN cp /bin/bash /bin/bash-mod \
+    && setcap cap_ipc_lock=+ep /bin/bash-mod \
+    && setcap cap_sys_resource=+ep /bin/bash-mod
 
 COPY cassandra /usr/sbin/cassandra
 COPY nodetool /usr/bin/nodetool
@@ -37,4 +44,4 @@ EXPOSE 7000 7001 7199 9042 9160
 # The user is created in ./install-cassandra
 USER 999
 
-ENTRYPOINT ["/usr/bin/entry-point"]
+ENTRYPOINT ["/usr/bin/wrapper"]

--- a/docker/cassandra/entry-point
+++ b/docker/cassandra/entry-point
@@ -12,4 +12,9 @@ do
 done
 )
 
+# Set unlimited memory locking only when running with kernel tweaks enabled.
+if [ -n "${MEMORY_LOCK-}" ] && [ "${MEMORY_LOCK}" == "true" ]; then
+    ulimit -l unlimited
+fi
+
 exec /usr/sbin/cassandra

--- a/docker/cassandra/entry-point
+++ b/docker/cassandra/entry-point
@@ -13,7 +13,7 @@ done
 )
 
 # Set unlimited memory locking only when running with kernel tweaks enabled.
-if [ -n "${MEMORY_LOCK-}" ] && [ "${MEMORY_LOCK}" == "true" ]; then
+if [ "${MEMORY_LOCK-unset}" == "true" ]; then
     ulimit -l unlimited
 fi
 

--- a/docker/cassandra/install-cassandra
+++ b/docker/cassandra/install-cassandra
@@ -22,7 +22,7 @@ dagi dpkg-dev cpio
 
 # install C*
 echo "deb file:${pkg_dir} ${arch}/" > /etc/apt/sources.list.d/cassandra.sources.list
-APT_GET_OPTS="--allow-unauthenticated" dagi cassandra cassandra-tools
+APT_GET_OPTS="--allow-unauthenticated" dagi cassandra cassandra-tools libcap2-bin
 
 # package "cleanup"
 mkdir /usr/share/cassandra/agents

--- a/docker/cassandra/wrapper
+++ b/docker/cassandra/wrapper
@@ -16,7 +16,7 @@
 # and for allowing Cassandra to lock memory.
 
 if [ -n "${MEMORY_LOCK-}" ] && [ "${MEMORY_LOCK}" == "true" ]; then
-    exec /bin/bash-mod -xue /usr/bin/entry-point
+    exec /bin/bash-mod -xue /usr/bin/entry-point "$@"
 else
-    exec /bin/bash -xue /usr/bin/entry-point
+    exec /bin/bash -xue /usr/bin/entry-point "$@"
 fi

--- a/docker/cassandra/wrapper
+++ b/docker/cassandra/wrapper
@@ -1,0 +1,22 @@
+#!/bin/bash -xue
+
+# This wrapper script executes the entrypoint script using one of two interpreters:
+#
+# If the $MEMORY_LOCK environment variable is set to "true", the entrypoint script
+# is invoked using /bin/bash-mod, which is an exact copy of the /bin/bash binary
+# but it also has the following capabilities at the executable level (added using
+# `setcap`):
+# - IPC_LOCK - allows locking memory
+# - SYS_RESOURCE - allows changing ulimit values
+#
+# If the $MEMORY_LOCK environment isn't set to "true" or is simply unset, the
+# entrypoint script is invoked using the regualr /bin/bash.
+#
+# This is required in order to allow the entrypoint script to make ulimit changes
+# and for allowing Cassandra to lock memory.
+
+if [ -n "${MEMORY_LOCK-}" ] && [ "${MEMORY_LOCK}" == "true" ]; then
+    exec /bin/bash-mod -xue /usr/bin/entry-point
+else
+    exec /bin/bash -xue /usr/bin/entry-point
+fi

--- a/docker/cassandra/wrapper
+++ b/docker/cassandra/wrapper
@@ -15,7 +15,7 @@
 # This is required in order to allow the entrypoint script to make ulimit changes
 # and for allowing Cassandra to lock memory.
 
-if [ -n "${MEMORY_LOCK-}" ] && [ "${MEMORY_LOCK}" == "true" ]; then
+if [ "${MEMORY_LOCK-unset}" == "true" ]; then
     exec /bin/bash-mod -xue /usr/bin/entry-point "$@"
 else
     exec /bin/bash -xue /usr/bin/entry-point "$@"

--- a/examples/go/example-datacenter.yaml
+++ b/examples/go/example-datacenter.yaml
@@ -55,4 +55,4 @@ spec:
         storage: 500Mi
 
   prometheusSupport: false
-  privilegedSupported: true
+  optimizeKernelParams: true

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-resty/resty/v2 v2.0.0
 	github.com/google/uuid v1.1.1
 	github.com/operator-framework/operator-sdk v0.10.1-0.20190809033248-9d6ffddcd86f
+	github.com/pkg/errors v0.8.1
 	github.com/spf13/pflag v1.0.3
 	gopkg.in/yaml.v2 v2.2.2
 	gotest.tools v2.2.0+incompatible

--- a/pkg/apis/cassandraoperator/v1alpha1/cassandradatacenter_types.go
+++ b/pkg/apis/cassandraoperator/v1alpha1/cassandradatacenter_types.go
@@ -23,7 +23,7 @@ type CassandraDataCenterSpec struct {
 	UserConfigMapVolumeSource *v1.ConfigMapVolumeSource    `json:"userConfigMapVolumeSource,omitempty"`
 	Resources                 v1.ResourceRequirements      `json:"resources"`
 	DataVolumeClaimSpec       v1.PersistentVolumeClaimSpec `json:"dataVolumeClaimSpec"`
-	PrivilegedSupported       bool                         `json:"privilegedSupported,omitempty"`
+	OptimizeKernelParams      bool                         `json:"optimizeKernelParams,omitempty"`
 	PrometheusSupport         bool                         `json:"prometheusSupport"`
 	SidecarEnv                []v1.EnvVar                  `json:"sidecarEnv,omitempty"`
 	CassandraEnv              []v1.EnvVar                  `json:"cassandraEnv,omitempty"`

--- a/pkg/apis/cassandraoperator/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/cassandraoperator/v1alpha1/zz_generated.openapi.go
@@ -395,7 +395,7 @@ func schema_pkg_apis_cassandraoperator_v1alpha1_CassandraDataCenterSpec(ref comm
 							Ref: ref("k8s.io/api/core/v1.PersistentVolumeClaimSpec"),
 						},
 					},
-					"privilegedSupported": {
+					"optimizeKernelParams": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"boolean"},
 							Format: "",

--- a/pkg/controller/cassandradatacenter/helpers.go
+++ b/pkg/controller/cassandradatacenter/helpers.go
@@ -81,3 +81,8 @@ func rackExist(name string, sets []v1.StatefulSet) bool {
 	}
 	return false
 }
+
+// boolPointer returns a pointer to bool b.
+func boolPointer(b bool) *bool {
+	return &b
+}

--- a/pkg/controller/cassandradatacenter/statefulset.go
+++ b/pkg/controller/cassandradatacenter/statefulset.go
@@ -178,6 +178,10 @@ func newCassandraContainer(
 				},
 			},
 		}
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  "MEMORY_LOCK",
+			Value: "true",
+		})
 	}
 
 	if userConfigVolume != nil {

--- a/pkg/controller/cassandradatacenter/statefulset.go
+++ b/pkg/controller/cassandradatacenter/statefulset.go
@@ -223,12 +223,12 @@ func newSidecarContainer(
 func newSysctlLimitsContainer(cdc *cassandraoperatorv1alpha1.CassandraDataCenter) *corev1.Container {
 	return &corev1.Container{
 		Name:            "sysctl-limits",
-		Image:           cdc.Spec.CassandraImage,
+		Image:           "busybox:latest",
 		ImagePullPolicy: cdc.Spec.ImagePullPolicy,
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: boolPointer(true),
 		},
-		Command: []string{"bash", "-xuec"},
+		Command: []string{"sh", "-xuec"},
 		Args: []string{
 			`sysctl -w vm.max_map_count=1048575`,
 		},


### PR DESCRIPTION
## General

This PR makes kernel performance tweaks optional. These are controlled using the `optimizeKernelParams` field in the CRD.

## Modes of Operation

### Default Behavior

By default, the C* pods created by the operator will run in the following mode:

- `sysctl` isn't called (the init container isn't included in the pod).
- `ulimit` isn't called.
- `disk_access_mode` is set to the default (`auto`).
- C* is unable to use the `mlock`/`mlockall` syscalls. A warning is written to the log.

### Kernel Tweaks Enabled

When the user sets `optimizeKernelParams` to `true`, the C* pods will run in the following mode:

- `sysctl -w vm.max_map_count=1048575` is executed in an init container. This changes the parameter **globally** on the host. Any related documentation should reflect that.
- `ulimit -l unlimited` is executed on C* startup. This change affects only the C* container.
- `disk_access_mode` is set to `mmap`. C* is able to lock memory.

## Implementation

The above is achieved with the C* container running without `privileged: true` and without running the process inside the container as root. This greatly reduces various security risks.

The above is implemented by conditionally using a Bash binary which has just the required capabilities for running `ulimit` and for performing memory locking. The reason I've implemented it this way:

- At the time of writing, setting Linux resource limits via k8s [isn't supported](https://github.com/kubernetes/kubernetes/issues/3595).
- A workaround is to call `ulimit` from within the container. To do so *without running as root*, the executed **binary** must have the `SYS_RESOURCE` capability. In our case that executable is Bash which is the interpreter used in the container's entrypoint.
- In order to be able to lock memory, a process needs the `IPC_LOCK` capability. To achieve that without running as root, we add that capability to the entrypoint's executable, similarly to the above.