### PR TITLE
Add support for tolerations and affinity

### DIFF
--- a/docker/base-openjre/Dockerfile
+++ b/docker/base-openjre/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stretch
 
-ARG openjre_version=8u212-b01-1~deb9u1
+ARG openjre_version=8u222-b10-1~deb9u1
 
 COPY dagi /usr/local/bin/
 

--- a/docker/base-openjre/Makefile
+++ b/docker/base-openjre/Makefile
@@ -1,6 +1,6 @@
 include ../../Makefile.inc
 
-OPENJRE_VERSION := 8u212-b01-1~deb9u1
+OPENJRE_VERSION := 8u222-b10-1~deb9u1
 OPENJRE_IMAGE_TAG := stretch-$(subst ~,-,$(OPENJRE_VERSION))
 OPENJRE_IMAGE := $(DOCKER_REPO)base-openjre:$(OPENJRE_IMAGE_TAG)
 

--- a/helm/cassandra/templates/cassandra.yaml
+++ b/helm/cassandra/templates/cassandra.yaml
@@ -41,3 +41,5 @@ spec:
 {{- end }}
   prometheusSupport: {{ .Values.prometheusEnabled }}
   privilegedSupported: {{ .Values.privilegedSupported }}
+  affinity: {{ .Values.affinity}}
+  tolerations: {{ .Values.tolerations}}

--- a/helm/cassandra/templates/cassandra.yaml
+++ b/helm/cassandra/templates/cassandra.yaml
@@ -41,5 +41,13 @@ spec:
 {{- end }}
   prometheusSupport: {{ .Values.prometheusEnabled }}
   privilegedSupported: {{ .Values.privilegedSupported }}
-  affinity: {{ .Values.affinity}}
-  tolerations: {{ .Values.tolerations}}
+
+{{- if .Values.affinity }}  
+  affinity: 
+{{ toYaml .Values.affinity | indent 4 }}  
+{{- end }}
+
+{{- if .Values.tolerations }}  
+  tolerations: 
+{{ toYaml .Values.tolerations | indent 4 }}  
+{{- end }}

--- a/helm/cassandra/values.yaml
+++ b/helm/cassandra/values.yaml
@@ -67,3 +67,5 @@ dataVolumeClaim:
 #restoreFromBackup: backup-hostname
 
 prometheusEnabled: false
+tolerations: []
+affinity: {}

--- a/java/model/src/main/resources/schema/CassandraDataCenter.json
+++ b/java/model/src/main/resources/schema/CassandraDataCenter.json
@@ -81,6 +81,19 @@
         "privilegedSupported": {
           "type": "boolean",
           "description": "Attempt to run privileged configuration options for better performance"
+        },
+        "affinity": {
+          "description": "Group of affinity scheduling rules. See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity",
+          "type": "object",
+          "javaType": "io.kubernetes.client.models.V1Affinity"
+        },
+        "tolerations": {
+          "description": "List of pod tolerations. See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "javaType": "io.kubernetes.client.models.V1Toleration"
+          }
         }
       }
     }

--- a/java/operator/src/main/java/com/instaclustr/cassandra/operator/controller/DataCenterReconciliationController.java
+++ b/java/operator/src/main/java/com/instaclustr/cassandra/operator/controller/DataCenterReconciliationController.java
@@ -221,7 +221,12 @@ public class DataCenterReconciliationController {
                     .addVolumesItem(new V1Volume()
                             .name("sidecar-config-volume")
                             .emptyDir(new V1EmptyDirVolumeSource())
-                    );
+                    )
+                    .affinity(dataCenterSpec.getAffinity());
+            List<V1Toleration> tolerations = dataCenterSpec.getTolerations();
+            if(tolerations != null) {
+                tolerations.forEach((V1Toleration toleration) -> podSpec.addTolerationsItem(toleration));
+            }
 
             {
                 final String secret = dataCenterSpec.getImagePullSecret();

--- a/java/operator/src/main/resources/com/instaclustr/datacenter-crd.yaml
+++ b/java/operator/src/main/resources/com/instaclustr/datacenter-crd.yaml
@@ -80,4 +80,11 @@ spec:
             privilegedSupported:
               type: boolean
               description: Attempt to run privileged configuration options for better performance.
+            affinity:
+              type: object
+              description: "Group of affinity scheduling rules. See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity"
+            tolerations:
+              type: array
+              description: "List of pod tolerations. See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/"
+
             


### PR DESCRIPTION
Adds support for passing tolerations and affinity to the pod spec inside stateful set .
It also includes fixes for java image

**Purpose**
- With affinity and anti-affinity, we can target Cassandra nodes to be distributed across Kubernetes nodes. No 2 pods 
- With tolerations, we can target Cassandra nodes to be run on nodes dedicated to Cassandra.