### PR TITLE
CI gofmt check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,35 @@
 # Java Maven CircleCI 2.0 configuration file
 #
-# Check https://circleci.com/docs/2.0/language-java/ for more details
 #
 version: 2
 jobs:
+  style-check:
+    docker:
+      - image: circleci/golang:1.13.0
+
+    working_directory: ~/cassandra-operator
+    steps:
+      - checkout
+      - restore_cache: # restores saved cache if no changes are detected since last run
+          keys:
+            - go-mod-v4-{{ checksum "go.sum" }}
+      - run:
+          name: Update go stuff
+          command: go get golang.org/x/tools/cmd/goimports && go mod download
+
+      - save_cache:
+          key: go-mod-v4-{{ checksum "go.sum" }}
+          paths:
+            - "/go/pkg/mod"
+      - run:
+          name: Check go formatting
+          command: |
+            files=$(goimports -l .)
+            if [ -n "$files" ]; then
+              echo "The following file(s) are not properly formatted or their imports are misaligned. Run go fmt/go imports on your code:"
+              echo "$files"
+              exit 1
+            fi
   build:
     docker:
       # specify the version you desire here
@@ -11,19 +37,29 @@ jobs:
         auth:
           username: _json_key
           password: $GOOGLE_AUTH
-    
+
     working_directory: ~/cassandra-operator
 
     environment:
       # Customize the JVM maximum heap limit
       MAVEN_OPTS: -Xmx3200m
-    
+
     steps:
       - checkout
 
-      - setup_remote_docker
+      - restore_cache: # restores saved cache if no changes are detected since last run
+          keys:
+            - m2
+
+      - setup_remote_docker:
+          docker_layer_caching: true
 
       - run: make
+
+      - save_cache:
+          key: m2
+          paths:
+            - ~/.m2
 
   release-dev:
     docker:
@@ -109,7 +145,10 @@ workflows:
   version: 2
   build_and_test:
     jobs:
+      - style-check
       - build:
+          requires:
+            - style-check
           filters:
             branches:
               ignore:
@@ -117,8 +156,14 @@ workflows:
                 - superdupertopsecretrewrite
       - test-gcp:
           requires:
+            - style-check
             - release-dev
+          filters:
+            branches:
+                only: /!^pull\/.*/
       - release-dev:
+          requires:
+            - style-check
           filters:
             branches:
               only:

--- a/docker/cassandra-operator/Dockerfile
+++ b/docker/cassandra-operator/Dockerfile
@@ -1,8 +1,6 @@
-FROM golang AS builder
+FROM golang:1.13 AS builder
 
 ARG version
-
-ENV GOPROXY=https://proxy.golang.org
 
 # Create a user so that operator can run as non-root
 RUN useradd -u 999 cassandra-operator

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/instaclustr/cassandra-operator
 
 require (
-	github.com/NYTimes/gziphandler v1.0.1 // indirect
 	github.com/coreos/prometheus-operator v0.32.0 // indirect
 	github.com/go-logr/logr v0.1.0
 	github.com/go-openapi/spec v0.19.0
@@ -39,5 +38,7 @@ replace (
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.1.12
 	sigs.k8s.io/controller-tools => sigs.k8s.io/controller-tools v0.1.11-0.20190411181648-9d55346c2bde
 )
+
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 
 replace github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,6 @@ cloud.google.com/go v0.37.2 h1:4y4L7BdHenTfZL0HervofNTHh9Ad6mNX72cQvl+5eH0=
 cloud.google.com/go v0.37.2/go.mod h1:H8IAquKe2L30IxoupDgqTaQvKSwF/c8prYHynGIWQbA=
 contrib.go.opencensus.io/exporter/ocagent v0.4.11 h1:Zwy9skaqR2igcEfSVYDuAsbpa33N0RPtnYTHEe2whPI=
 contrib.go.opencensus.io/exporter/ocagent v0.4.11/go.mod h1:7ihiYRbdcVfW4m4wlXi9WRPdv79C0fStcjNlyE6ek9s=
-git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
-git.apache.org/thrift.git v0.12.0/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest v11.1.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest v11.7.0+incompatible h1:gzma19dc9ejB75D90E5S+/wXouzpZyA+CV+/MJPSD/k=
@@ -33,6 +31,7 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
+github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30 h1:Kn3rqvbUFqSepE2OqVu0Pn1CbDw9IuMlONapol0zuwk=
 github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30/go.mod h1:4AJxUpXUhv4N+ziTvIcWWXgeorXpxPZOfk9HdEVr96M=

--- a/test/e2e/cassandra_test.go
+++ b/test/e2e/cassandra_test.go
@@ -2,13 +2,14 @@ package e2e
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/instaclustr/cassandra-operator/pkg/apis"
 	cassandraoperatorv1alpha1 "github.com/instaclustr/cassandra-operator/pkg/apis/cassandraoperator/v1alpha1"
 	"github.com/instaclustr/cassandra-operator/pkg/common/cluster"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 const (

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,8 +1,9 @@
 package e2e
 
 import (
-	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"testing"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
 )
 
 func TestMain(m *testing.M) {

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -3,6 +3,10 @@ package e2e
 import (
 	goctx "context"
 	"fmt"
+	"os"
+	"testing"
+	"time"
+
 	operator "github.com/instaclustr/cassandra-operator/pkg/apis/cassandraoperator/v1alpha1"
 	"github.com/instaclustr/cassandra-operator/pkg/common/nodestate"
 	"github.com/instaclustr/cassandra-operator/pkg/sidecar"
@@ -14,9 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"os"
-	"testing"
-	"time"
 )
 
 const (


### PR DESCRIPTION
This adds the `goimports` check to CI validating that the code is properly formatted and imports are aligned (cleaned, grouped and sorted alphabetically)