### PR TITLE
Allow specifying fsGroup for C* pods

### DIFF
--- a/deploy/crds/cassandraoperator_v1alpha1_cassandradatacenter_crd.yaml
+++ b/deploy/crds/cassandraoperator_v1alpha1_cassandradatacenter_crd.yaml
@@ -39,6 +39,9 @@ spec:
               type: string
             dataVolumeClaimSpec:
               type: object
+            fsGroup:
+              format: int64
+              type: integer
             imagePullPolicy:
               type: string
             imagePullSecrets:

--- a/pkg/apis/cassandraoperator/v1alpha1/cassandradatacenter_types.go
+++ b/pkg/apis/cassandraoperator/v1alpha1/cassandradatacenter_types.go
@@ -25,6 +25,7 @@ type CassandraDataCenterSpec struct {
 	SidecarEnv                []v1.EnvVar                   `json:"sidecarEnv,omitempty"`
 	CassandraEnv              []v1.EnvVar                   `json:"cassandraEnv,omitempty"`
 	ServiceAccountName        string                        `json:"serviceAccountName,omitempty"`
+	FSGroup                   int64                         `json:"fsGroup,omitempty"`
 }
 
 // CassandraDataCenterStatus defines the observed state of CassandraDataCenter

--- a/pkg/apis/cassandraoperator/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/cassandraoperator/v1alpha1/zz_generated.openapi.go
@@ -430,6 +430,12 @@ func schema_pkg_apis_cassandraoperator_v1alpha1_CassandraDataCenterSpec(ref comm
 							Format: "",
 						},
 					},
+					"fsGroup": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int64",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
The `fsGroup` field in a pod's SecurityContext allows controlling the GID of volume mounts. This is important when non-root processes need write permissions to k8s volumes.