### PR TITLE
Add default operator config ConfigMap

### DIFF
--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cassandra-operator-default-config
+data:
+  nodes: "3"
+  cassandraImage: gcr.io/cassandra-operator/cassandra:3.11.4
+  sidecarImage: gcr.io/cassandra-operator/cassandra-sidecar:latest
+  memory: 1Gi
+  disk: 1Gi


### PR DESCRIPTION
The operator depends on this ConfigMap so we need to deploy it along with the operator.