### PR TITLE
Improve deployment UX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,5 +23,10 @@ helm:
 docker: java
 	$(MAKE) -C $@
 
+# Render YAML bundles from official manifests
+.PHONY: bundle
+bundle:
+	buildenv/bundle
+
 
 .DEFAULT_GOAL := all

--- a/buildenv/bundle
+++ b/buildenv/bundle
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -eux pipefail
+
+manifest_dir="$(git rev-parse --show-toplevel)/deploy"
+
+crd_files="
+    crds/cassandraoperator_v1alpha1_cassandrabackup_crd.yaml
+    crds/cassandraoperator_v1alpha1_cassandracluster_crd.yaml
+    crds/cassandraoperator_v1alpha1_cassandradatacenter_crd.yaml
+"
+crd_output="${manifest_dir}"/crds.yaml
+
+operator_files="
+    cassandra/psp.yaml
+    cassandra/psp_performance.yaml
+    configmap.yaml
+    operator.yaml
+    psp.yaml
+    role_binding.yaml
+    role.yaml
+    service_account.yaml
+"
+operator_output="${manifest_dir}"/bundle.yaml
+
+bundle_yaml_files () {
+    directory=${1}
+    files=${2}
+    output_file=${3}
+
+    # Empty output file before writing for idempotency.
+    echo -n > "${output_file}"
+
+    for f in ${files}; do
+        echo '---' >> "${output_file}"
+        cat "${directory}"/"${f}" >> "${output_file}"
+    done
+}
+
+echo "Bundling CRD manifests"
+
+bundle_yaml_files "${manifest_dir}" "${crd_files}" "${crd_output}"
+
+echo "Done bundling CRD manifests"
+
+echo "Bundling operator manifests"
+
+bundle_yaml_files "${manifest_dir}" "${operator_files}" "${operator_output}"
+
+echo "Done bundling operator manifests"

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -1,0 +1,317 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cassandra
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: cassandra
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - cassandra
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cassandra
+subjects:
+  - kind: ServiceAccount
+    name: cassandra
+roleRef:
+  kind: Role
+  name: cassandra
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: cassandra
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+  volumes:
+  - 'configMap'
+  - 'emptyDir'
+  - 'projected'
+  - 'secret'
+  - 'downwardAPI'
+  - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  readOnlyRootFilesystem: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cassandra-performance
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: cassandra-performance
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - cassandra-performance
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cassandra-performance
+subjects:
+  - kind: ServiceAccount
+    name: cassandra-performance
+roleRef:
+  kind: Role
+  name: cassandra-performance
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: cassandra-performance
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - IPC_LOCK
+  - SYS_RESOURCE
+  requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+  volumes:
+  - 'configMap'
+  - 'emptyDir'
+  - 'projected'
+  - 'secret'
+  - 'downwardAPI'
+  - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  readOnlyRootFilesystem: false
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cassandra-operator-default-config
+data:
+  nodes: "3"
+  cassandraImage: gcr.io/cassandra-operator/cassandra:3.11.4
+  sidecarImage: gcr.io/cassandra-operator/cassandra-sidecar:latest
+  memory: 1Gi
+  disk: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cassandra-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: cassandra-operator
+  template:
+    metadata:
+      labels:
+        name: cassandra-operator
+    spec:
+      serviceAccountName: cassandra-operator
+      containers:
+        - name: cassandra-operator
+          image: "gcr.io/cassandra-operator/cassandra-operator:latest"
+          command:
+          - ./cassandra-operator
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "cassandra-operator"
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: cassandra-operator
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+  volumes:
+  - 'configMap'
+  - 'emptyDir'
+  - 'projected'
+  - 'secret'
+  - 'downwardAPI'
+  - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  readOnlyRootFilesystem: true
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cassandra-operator
+subjects:
+- kind: ServiceAccount
+  name: cassandra-operator
+roleRef:
+  kind: Role
+  name: cassandra-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: cassandra-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - cassandra-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - cassandraoperator.instaclustr.com
+  resources:
+  - '*'
+  - cassandraclusters
+  - cassandrabackups
+  verbs:
+  - '*'
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - cassandra-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cassandra-operator

--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cassandra-operator-default-config
+data:
+  nodes: "3"
+  cassandraImage: gcr.io/cassandra-operator/cassandra:3.11.4
+  sidecarImage: gcr.io/cassandra-operator/cassandra-sidecar:latest
+  memory: 1Gi
+  disk: 1Gi

--- a/deploy/crds.yaml
+++ b/deploy/crds.yaml
@@ -1,0 +1,231 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cassandrabackups.cassandraoperator.instaclustr.com
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .globalStatus
+    description: Backup operation status
+    name: Status
+    type: string
+  - JSONPath: .globalProgress
+    description: Backup operation progress
+    name: Progress
+    type: string
+  group: cassandraoperator.instaclustr.com
+  names:
+    kind: CassandraBackup
+    listKind: CassandraBackupList
+    plural: cassandrabackups
+    singular: cassandrabackup
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        globalProgress:
+          type: string
+        globalStatus:
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            bandwidth:
+              type: string
+            cdc:
+              description: Cassandra DC name to back up. Used to find the pods in
+                the CDC
+              type: string
+            concurrentConnections:
+              format: int64
+              type: integer
+            duration:
+              type: string
+            keyspaces:
+              description: The list of keyspaces to back up
+              items:
+                type: string
+              type: array
+            snapshotTag:
+              description: The snapshot tag for the backup
+              type: string
+            storageLocation:
+              description: The uri for the backup target location e.g. s3 bucket,
+                filepath
+              type: string
+            table:
+              type: string
+          required:
+          - cdc
+          - storageLocation
+          - snapshotTag
+          type: object
+        status:
+          items:
+            properties:
+              node:
+                description: name of pod / node
+                type: string
+              progress:
+                description: Progress shows the percentage of the operation done
+                type: string
+              state:
+                description: State shows the status of the operation
+                type: string
+            required:
+            - node
+            - state
+            - progress
+            type: object
+          type: array
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cassandraclusters.cassandraoperator.instaclustr.com
+spec:
+  group: cassandraoperator.instaclustr.com
+  names:
+    kind: CassandraCluster
+    listKind: CassandraClusterList
+    plural: cassandraclusters
+    singular: cassandracluster
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cassandradatacenters.cassandraoperator.instaclustr.com
+spec:
+  group: cassandraoperator.instaclustr.com
+  names:
+    kind: CassandraDataCenter
+    listKind: CassandraDataCenterList
+    plural: cassandradatacenters
+    singular: cassandradatacenter
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            backupSecretVolumeSource:
+              type: object
+            cassandraEnv:
+              items:
+                type: object
+              type: array
+            cassandraImage:
+              type: string
+            dataVolumeClaimSpec:
+              type: object
+            fsGroup:
+              format: int64
+              type: integer
+            imagePullPolicy:
+              type: string
+            imagePullSecrets:
+              items:
+                type: object
+              type: array
+            nodes:
+              format: int32
+              type: integer
+            optimizeKernelParams:
+              type: boolean
+            prometheusSupport:
+              type: boolean
+            racks:
+              items:
+                properties:
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  name:
+                    type: string
+                required:
+                - name
+                - labels
+                type: object
+              type: array
+            resources:
+              type: object
+            restoreFromBackup:
+              type: string
+            serviceAccountName:
+              type: string
+            sidecarEnv:
+              items:
+                type: object
+              type: array
+            sidecarImage:
+              type: string
+            userConfigMapVolumeSource:
+              type: object
+            userSecretVolumeSource:
+              type: object
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/psp.yaml
+++ b/deploy/psp.yaml
@@ -1,0 +1,40 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: cassandra-operator
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+  volumes:
+  - 'configMap'
+  - 'emptyDir'
+  - 'projected'
+  - 'secret'
+  - 'downwardAPI'
+  - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  readOnlyRootFilesystem: true

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,0 +1,71 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: cassandra-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - cassandra-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - cassandraoperator.instaclustr.com
+  resources:
+  - '*'
+  - cassandraclusters
+  - cassandrabackups
+  verbs:
+  - '*'
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - cassandra-operator

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,0 +1,11 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cassandra-operator
+subjects:
+- kind: ServiceAccount
+  name: cassandra-operator
+roleRef:
+  kind: Role
+  name: cassandra-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cassandra-operator

--- a/doc/op_guide.md
+++ b/doc/op_guide.md
@@ -1,32 +1,17 @@
-## Installing the Cassandra operator
+## Installing the Cassandra Operator
 
 ### Deploy the Operator
 
  1) Deploy the [CRDs][crds] used by the operator to manage Cassandra clusters:
 
     ```
-    kubectl apply -f deploy/crds/cassandraoperator_v1alpha1_cassandrabackup_crd.yaml
-    kubectl apply -f deploy/crds/cassandraoperator_v1alpha1_cassandracluster_crd.yaml
-    kubectl apply -f deploy/crds/cassandraoperator_v1alpha1_cassandradatacenter_crd.yaml
+    kubectl apply -f deploy/crds.yaml
     ```
 
- 1) Deploy the [RBAC][rbac] resources and [pod security policies][psps] needed for the operator to run:
-    ```
-    kubectl apply -f deploy/operator_bundle.yaml
-    ```
- 1) Deploy the [RBAC][rbac] resources and [pod security policies][psps] used by the operator to create
-Cassandra pods:
-
-    >TODO: Remove this? This isn't mandatory on AKS as things work fine with the `default` SA.
+ 1) Deploy the operator:
 
     ```
-    kubectl apply -f deploy/cassandra
-    ```
-
- 1) Deploy the operator itself:
-
-    ```
-    kubectl apply -f deploy/operator.yaml
+    kubectl apply -f deploy/bundle.yaml
     ```
 
  1) Verify the operator is running:
@@ -39,7 +24,7 @@ Cassandra pods:
     cassandra-operator-5755f6855f-t9hvm   1/1     Running   0          65s
     ```
     
-### Deploy a Cassandra cluster
+### Deploy a Cassandra Cluster
 
  1) To deploy a cluster on AKS, refer to [Running a cluster on AKS](providers/aks.md)
  1) To deploy a cluster on GKE, refer to [Running a cluster on GKE](providers/gke.md)

--- a/examples/example-datacenter-minimal.yaml
+++ b/examples/example-datacenter-minimal.yaml
@@ -2,3 +2,5 @@ apiVersion: cassandraoperator.instaclustr.com/v1alpha1
 kind: CassandraDataCenter
 metadata:
   name: test-dc-cassandra
+spec:
+  serviceAccountName: cassandra

--- a/examples/example-datacenter.yaml
+++ b/examples/example-datacenter.yaml
@@ -78,5 +78,6 @@ spec:
 
   prometheusSupport: false
   optimizeKernelParams: true
+  serviceAccountName: cassandra-performance
   # Needed to run on AKS
   fsGroup: 999


### PR DESCRIPTION
- Restore manifests removed in https://github.com/instaclustr/cassandra-operator/pull/283.
- Add a Make target for generating deployment bundles for CRDs and the operator (`make bundle`).
- Update `op_guide.md`.
- Include `serviceAccountName` in examples.