### PR TITLE
Added more checks in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,33 +3,23 @@
 #
 version: 2
 jobs:
-  style-check:
+  repo-check:
     docker:
       - image: circleci/golang:1.13.0
 
-    working_directory: ~/cassandra-operator
+    working_directory: /go/src/github.com/instaclustr/cassandra-operator
     steps:
       - checkout
       - restore_cache: # restores saved cache if no changes are detected since last run
           keys:
             - go-mod-v4-{{ checksum "go.sum" }}
       - run:
-          name: Update go stuff
-          command: go get golang.org/x/tools/cmd/goimports && go mod download
-
+          name: Validate repository
+          command: GO111MODULE=on .circleci/validate_repo.sh
       - save_cache:
           key: go-mod-v4-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"
-      - run:
-          name: Check go formatting
-          command: |
-            files=$(goimports -l .)
-            if [ -n "$files" ]; then
-              echo "The following file(s) are not properly formatted or their imports are misaligned. Run go fmt/go imports on your code:"
-              echo "$files"
-              exit 1
-            fi
   build:
     docker:
       # specify the version you desire here
@@ -170,17 +160,18 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - style-check
+      - repo-check
       - build:
           requires:
-            - style-check
+            - repo-check
           filters:
             branches:
               ignore:
                 - master
       - test-gcp:
           requires:
-            - style-check
+            - repo-check
+            - release
           filters:
             branches:
                 # Don't run the test on PRs
@@ -188,7 +179,7 @@ workflows:
                   - /^pull\/.*/
       - release:
           requires:
-            - style-check
+            - repo-check
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+$/

--- a/.circleci/validate_repo.sh
+++ b/.circleci/validate_repo.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+set -uxo pipefail
+
+top_dir="$(git rev-parse --show-toplevel)"
+cd $top_dir
+
+echo "Validate repository state"
+
+function check-bundle {
+    make bundle
+    git diff --quiet
+    if [[ $? != 0 ]]; then
+        echo "Bundles were not properly built, make sure to run 'make bundle'"
+        exit 1
+    fi
+}
+
+function update-go-modules {
+    go get golang.org/x/tools/cmd/goimports && go mod download
+}
+
+function check-go-formatting {
+    files=$(goimports -l .)
+    if [ -n "$files" ]; then
+        echo "The following file(s) are not properly formatted or their imports are misaligned. Run go fmt/go imports on your code:"
+        echo "$files"
+        exit 1
+    fi
+}
+
+function install-operator-sdk {
+    RELEASE_VERSION=v0.10.0
+    curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
+    curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu.asc
+    chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu && mv operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu operator-sdk
+}
+
+function check-open-api {
+    ./operator-sdk generate openapi
+    git diff --quiet --exit-code deploy/crds/cassandraoperator_*_cassandra*_crd.yaml
+    if [[ $? != 0 ]]; then
+        echo "API files were not regenerated with latest changes, make sure to run 'operator-sdk generate openapi'"
+        exit 1
+    fi
+}
+
+function check-k8s {
+    ./operator-sdk generate k8s
+    git diff --quiet --exit-code pkg/apis
+    if [[ $? != 0 ]]; then
+        echo "k8s files were not regenerated with latest changes, make sure to run 'operator-sdk generate k8s'"
+        exit 1
+    fi
+}
+
+echo "Check bundles"
+check-bundle
+
+echo "Update go modules"
+update-go-modules
+
+echo "Check go formatting"
+check-go-formatting
+
+echo "Install operator-sdk"
+install-operator-sdk
+
+echo "Check OpenAPI"
+check-open-api
+
+echo "Check k8s"
+check-k8s
+
+echo "All clean, you may continue"

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/instaclustr/cassandra-operator
 
 require (
-	github.com/NYTimes/gziphandler v1.0.1 // indirect
 	github.com/coreos/prometheus-operator v0.32.0 // indirect
 	github.com/go-logr/logr v0.1.0
 	github.com/go-openapi/spec v0.19.0
@@ -10,6 +9,8 @@ require (
 	github.com/operator-framework/operator-sdk v0.10.1-0.20190809033248-9d6ffddcd86f
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/pflag v1.0.3
+	golang.org/dl v0.0.0-20190916174333-7d514fe8af3a // indirect
+	golang.org/x/tools v0.0.0-20190924052046-3ac2a5bbd98a // indirect
 	gopkg.in/yaml.v2 v2.2.2
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.0.0-20190612125737-db0771252981
@@ -43,3 +44,5 @@ replace (
 replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 
 replace github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.10.0
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -378,6 +378,8 @@ go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/
 go.uber.org/zap v1.9.1 h1:XCJQEf3W6eZaVwhRBof6ImoYGJSITeKWsyeh3HFu/5o=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
+golang.org/dl v0.0.0-20190916174333-7d514fe8af3a h1:s2tcHwg7PXTOldeJr64ilm9oa7k6UhtHZWlw2DgVzho=
+golang.org/dl v0.0.0-20190916174333-7d514fe8af3a/go.mod h1:IUMfjQLJQd4UTqG1Z90tenwKoCX93Gn3MAQJMOSBsDQ=
 golang.org/x/build v0.0.0-20190314133821-5284462c4bec/go.mod h1:atTaCNAy0f16Ah5aV1gMSwgiKVHwu/JncqDpuRr7lS4=
 golang.org/x/crypto v0.0.0-20180222182404-49796115aa4b/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -413,6 +415,7 @@ golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7 h1:rTIdg5QFRR7XCaK4LCjBiPbx8j4DQRpdYMnGn/bJUEU=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20170412232759-a6bd8cefa181/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -429,6 +432,7 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 h1:bjcUS9ztw9kFmmIxJInhon/0Is3p+EHBKNgquIzo1OI=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -466,6 +470,13 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190408170212-12dd9f86f350 h1:0USRhKWpISljvJE8egltEaoJb+VD0IUA4eOH6W1yss8=
 golang.org/x/tools v0.0.0-20190408170212-12dd9f86f350/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190923230126-0f9bb8f614ff h1:palXc2/lH3aFG86BII2o6pUYgrcAjON5FyYk7zthL3Q=
+golang.org/x/tools v0.0.0-20190923230126-0f9bb8f614ff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20190924021748-035fdb12d3f0 h1:beqvqT6myEkc8rmrSLPS+MM/WtmSHV+CgGmwiar2BOg=
+golang.org/x/tools v0.0.0-20190924021748-035fdb12d3f0/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20190924052046-3ac2a5bbd98a h1:DJzZ1GRmbjp7ihxzAN6UTVpVMi6k4CXZEr7A3wi2kRA=
+golang.org/x/tools v0.0.0-20190924052046-3ac2a5bbd98a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181030000543-1d582fd0359e/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181220000619-583d854617af/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=


### PR DESCRIPTION
Additional "repo" checks in CI will validate that OpenAPI and k8s
objects are in sync with the code changes; as well as that `make bundle`
was rerun and is also in sync with the current code state.

Signed-off-by: Alex Lourie <djay.il@gmail.com>