### PR TITLE
Remove creationTimestamp field from PSP manifests

### DIFF
--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -7,7 +7,6 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
   name: cassandra
 rules:
 - apiGroups: ['policy']
@@ -77,7 +76,6 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
   name: cassandra-performance
 rules:
 - apiGroups: ['policy']

--- a/deploy/cassandra/psp.yaml
+++ b/deploy/cassandra/psp.yaml
@@ -6,7 +6,6 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
   name: cassandra
 rules:
 - apiGroups: ['policy']

--- a/deploy/cassandra/psp_performance.yaml
+++ b/deploy/cassandra/psp_performance.yaml
@@ -6,7 +6,6 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
   name: cassandra-performance
 rules:
 - apiGroups: ['policy']


### PR DESCRIPTION
The field was accidentally copy-pasted when creating the manifests.