### PR TITLE
implemented EmptyDir volume for pod

### DIFF
--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -150,6 +150,7 @@ data:
   sidecarImage: gcr.io/cassandra-operator/cassandra-sidecar:latest
   memory: 1Gi
   disk: 1Gi
+  diskMedium: ""
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -8,3 +8,4 @@ data:
   sidecarImage: gcr.io/cassandra-operator/cassandra-sidecar:latest
   memory: 1Gi
   disk: 1Gi
+  diskMedium: ""

--- a/deploy/crds.yaml
+++ b/deploy/crds.yaml
@@ -175,6 +175,8 @@ spec:
               type: string
             dataVolumeClaimSpec:
               type: object
+            dummyVolume:
+              type: object
             fsGroup:
               format: int64
               type: integer

--- a/deploy/crds/cassandraoperator_v1alpha1_cassandradatacenter_crd.yaml
+++ b/deploy/crds/cassandraoperator_v1alpha1_cassandradatacenter_crd.yaml
@@ -39,6 +39,8 @@ spec:
               type: string
             dataVolumeClaimSpec:
               type: object
+            dummyVolume:
+              type: object
             fsGroup:
               format: int64
               type: integer

--- a/doc/op_guide.md
+++ b/doc/op_guide.md
@@ -50,7 +50,8 @@ It is possible to configure Cassandra by providing custom configuration. Refer t
 >       cassandraImage: gcr.io/cassandra-operator/cassandra:3.11.4
 >       sidecarImage: gcr.io/cassandra-operator/cassandra-sidecar:latest
 >       memory: 1Gi
->       disk: 1Gi 
+>       disk: 1Gi
+>       diskMedium: Memory
 >    ```
 > This configMap is already loaded into your k8 environment if you've used `deploy/bundle.yaml` to load operator's configuration.
 
@@ -187,6 +188,22 @@ It is possible to configure Cassandra by providing custom configuration. Refer t
     kubectl delete -f deploy/crds.yaml 
     ```
 
+### Using EmptyDir as volume for a pod
+
+If you do not specify `DataVolumeClaimSpec` in your spec, it will automatically use `EmptyDir` volume 
+from Kubernetes. You control that `EmptyDir` via field called `DummyVolume` in your spec.
+
+If `DummyVolume` is not specified either, it will take defauls from config map as described above.
+
+`DummyVolume` is of type `EmptyDirVolumeSource` so you can specify there `medium` and `sizeLimit`.
+`medium` is by default empty string `""` which means it will use a directory on pod. However, you can 
+also use `medium` as `Memory`. This means that your whole Cassandra node basically runs in memory as 
+`/var/lib/cassandra` where data are stored is actually memory mount.
+
+Using this volume type means that your data in Cassandra will live only until that pod is restarted hence it 
+might be handy for cases like performance testing or similar if you do not care about your data persistence.
+
+Use `Memory` medium with care as the `sizeLimit` eats memory from your limits. 
 
 [aks]: https://azure.microsoft.com/en-in/services/kubernetes-service/
 [gke]: https://console.cloud.google.com/kubernetes
@@ -194,3 +211,4 @@ It is possible to configure Cassandra by providing custom configuration. Refer t
 [psps]: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
 [rbac]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 [storage]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+[EmptyDir volume]: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir 

--- a/go.sum
+++ b/go.sum
@@ -432,6 +432,7 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 h1:bjcUS9ztw9kFmmIxJInhon/0Is3p+EHBKNgquIzo1OI=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/apis/cassandraoperator/v1alpha1/cassandradatacenter_types.go
+++ b/pkg/apis/cassandraoperator/v1alpha1/cassandradatacenter_types.go
@@ -19,6 +19,7 @@ type CassandraDataCenterSpec struct {
 	UserSecretVolumeSource         *v1.SecretVolumeSource        `json:"userSecretVolumeSource,omitempty"`
 	UserConfigMapVolumeSource      *v1.ConfigMapVolumeSource     `json:"userConfigMapVolumeSource,omitempty"`
 	Resources                      *v1.ResourceRequirements      `json:"resources,omitempty"`
+	DummyVolume                    *v1.EmptyDirVolumeSource      `json:"dummyVolume,omitempty"`
 	DataVolumeClaimSpec            *v1.PersistentVolumeClaimSpec `json:"dataVolumeClaimSpec,omitempty"`
 	OptimizeKernelParams           bool                          `json:"optimizeKernelParams,omitempty"`
 	PrometheusSupport              bool                          `json:"prometheusSupport,omitempty"`

--- a/pkg/apis/cassandraoperator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/cassandraoperator/v1alpha1/zz_generated.deepcopy.go
@@ -306,6 +306,11 @@ func (in *CassandraDataCenterSpec) DeepCopyInto(out *CassandraDataCenterSpec) {
 		*out = new(v1.ResourceRequirements)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.DummyVolume != nil {
+		in, out := &in.DummyVolume, &out.DummyVolume
+		*out = new(v1.EmptyDirVolumeSource)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.DataVolumeClaimSpec != nil {
 		in, out := &in.DataVolumeClaimSpec, &out.DataVolumeClaimSpec
 		*out = new(v1.PersistentVolumeClaimSpec)

--- a/pkg/apis/cassandraoperator/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/cassandraoperator/v1alpha1/zz_generated.openapi.go
@@ -383,6 +383,11 @@ func schema_pkg_apis_cassandraoperator_v1alpha1_CassandraDataCenterSpec(ref comm
 							Ref: ref("k8s.io/api/core/v1.ResourceRequirements"),
 						},
 					},
+					"dummyVolume": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("k8s.io/api/core/v1.EmptyDirVolumeSource"),
+						},
+					},
 					"dataVolumeClaimSpec": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("k8s.io/api/core/v1.PersistentVolumeClaimSpec"),
@@ -453,7 +458,7 @@ func schema_pkg_apis_cassandraoperator_v1alpha1_CassandraDataCenterSpec(ref comm
 			},
 		},
 		Dependencies: []string{
-			"github.com/instaclustr/cassandra-operator/pkg/apis/cassandraoperator/v1alpha1.Rack", "k8s.io/api/core/v1.ConfigMapVolumeSource", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.PersistentVolumeClaimSpec", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.SecretVolumeSource"},
+			"github.com/instaclustr/cassandra-operator/pkg/apis/cassandraoperator/v1alpha1.Rack", "k8s.io/api/core/v1.ConfigMapVolumeSource", "k8s.io/api/core/v1.EmptyDirVolumeSource", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.PersistentVolumeClaimSpec", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.SecretVolumeSource"},
 	}
 }
 


### PR DESCRIPTION
solves https://github.com/instaclustr/cassandra-operator/issues/165

This effectively enables people to run whole Cassandra cluster in memory or with normal disk but it is backed by `EmptyDir` from Kubernetes so no claims & co. are necessary ...

It is compatible with data volume claim we have currently, it will just fallback to EmptyDir if it is not specified.