### PR TITLE
added watch_namespace to values.yaml

### DIFF
--- a/helm/cassandra-operator/Chart.yaml
+++ b/helm/cassandra-operator/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
   - name: Ben Bromhead
   - name: Adam Zegelin
 name: cassandra-operator
-version: 1.1.0
+version: 1.1.1

--- a/helm/cassandra-operator/templates/deployment.yaml
+++ b/helm/cassandra-operator/templates/deployment.yaml
@@ -27,12 +27,14 @@ spec:
         - name: {{ template "cassandra-operator.name" . }}
           env:
             - name: WATCH_NAMESPACE
-# uncomment this "" to have cluster-scoped operator
-# and comment out the "valueFrom" section
-#              value: ""
+              {{- if eq .Values.watch_namespace "self" }}
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+              {{- else }}
+              value: {{ .Values.watch_namescape }}
+              {{- end }}
+
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/helm/cassandra-operator/values.yaml
+++ b/helm/cassandra-operator/values.yaml
@@ -27,4 +27,9 @@ tolerations: []
 
 affinity: {}
 
-namespace: "default"
+# Which namespace to watch for Cassandra objects.
+# use:
+# - <namespace-name>
+# - empty string "" is all namespaces
+# - 'self' is the namespace that the operator is installed in.
+watch_namespace: "self"


### PR DESCRIPTION
This change will allow setting the 'WATCH_NAMESPACE' behaviour from values.yaml so that it can be used with overrides, without having to edit the helm chart.

Thanks,
Frank