### PR TITLE
simplify if clause of optimizeKernelParams in cassandra helm template for go 1.14 compability

### DIFF
--- a/helm/cassandra/templates/cassandra.yaml
+++ b/helm/cassandra/templates/cassandra.yaml
@@ -74,7 +74,7 @@ spec:
 {{- if .Values.serviceAccountName }}
   serviceAccountName: {{ .Values.serviceAccountName }}
 {{- else}}
-{{- if (.Values.optimizeKernelParams) and eq .Values.optimizeKernelParams "true"}}
+{{- if .Values.optimizeKernelParams }}
   serviceAccountName: "cassandra-performance"
 {{- else}}
   serviceAccountName: "cassandra"


### PR DESCRIPTION
The infix position should not be used and results in an error starting with go 1.14, explanation [here](https://github.com/helm/helm/issues/7711#issuecomment-593113347). I've simplified the clause as used in e.g. [`passwordAuth`](https://github.com/instaclustr/cassandra-operator/blob/master/helm/cassandra/templates/cassandra.yaml#L84)

I've stumbled upon this one as I'm using the https://github.com/fluxcd/helm-operator which doesn't support helm registries yet, so I had to use the git repo as a source directly, in which case go 1.14 is used to build the helm file.